### PR TITLE
Make 'warn' the default log level in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,19 @@ You can use the `parse` task to parse Alda code into alda.lisp (`-l`/`--lisp`) a
       (alda.lisp/part {:names ["cello"]}
         (alda.lisp/note (alda.lisp/pitch :c :sharp))))
 
-## Logging
+## Log levels
 
-Alda uses [timbre](https://github.com/ptaoussanis/timbre) for logging. Every note event, attribute change, etc. is logged at the DEBUG level, which is useful for, well, debugging, but can otherwise be a little distracting. You may want to set Timbre's logging level to WARN, so that you'll only see warnings and errors. You can do that by setting an environment variable:
+Alda uses [timbre](https://github.com/ptaoussanis/timbre) for logging. Every note event, attribute change, etc. is logged at the DEBUG level, which can be useful for debugging purposes.
 
-    export TIMBRE_LOG_LEVEL=warn
+The default logging level is WARN, so by default, you will not see these debug-level logs; you will only see warnings and errors.
+
+To override this setting (e.g. for development and debugging), you can set the `TIMBRE_LEVEL` environment variable.
+
+To see debug logs, for example, you can do this:
+
+    export TIMBRE_LEVEL=debug
+
+When running tests via `boot test`, the log level will default to `debug` unless `TIMBRE_LEVEL` is set to something else.
 
 ## Contributing
 

--- a/build.boot
+++ b/build.boot
@@ -1,18 +1,16 @@
-#!/usr/bin/env boot
-
 (set-env!
- :source-paths #{"src" "test"}
- :resource-paths #{"grammar"}
- :dependencies '[[org.clojure/clojure   "1.7.0"]
-                 [org.clojure/tools.cli "0.3.1"]
-                 [instaparse            "1.4.1"]
-                 [adzerk/bootlaces      "0.1.11" :scope "test"]
-                 [adzerk/boot-test      "1.0.4"  :scope "test"]
-                 [com.taoensso/timbre   "3.4.0"]
-                 [djy                   "0.1.4"]
-                 [overtone              "0.9.1"]
-                 [midi.soundfont        "0.1.0"]
-                 [reply                 "0.3.7"]])
+  :source-paths #{"src" "test"}
+  :resource-paths #{"grammar"}
+  :dependencies '[[org.clojure/clojure   "1.7.0"]
+                  [org.clojure/tools.cli "0.3.1"]
+                  [instaparse            "1.4.1"]
+                  [adzerk/bootlaces      "0.1.12" :scope "test"]
+                  [adzerk/boot-test      "1.0.4"  :scope "test"]
+                  [com.taoensso/timbre   "4.1.1"]
+                  [djy                   "0.1.4"]
+                  [overtone              "0.9.1"]
+                  [midi.soundfont        "0.1.0"]
+                  [reply                 "0.3.7"]])
 
 (require '[adzerk.bootlaces :refer :all]
          '[adzerk.boot-test :refer :all]
@@ -48,5 +46,3 @@
                        alda.test.lisp.score
                        alda.test.lisp.voices}})
 
-(defn -main [& args]
-  (apply alda.cli/-main args))

--- a/src/alda/now.clj
+++ b/src/alda/now.clj
@@ -1,7 +1,13 @@
-(ns alda.now
-  (:require [alda.sound  :as sound]
-            [alda.lisp   :as lisp]
-            [clojure.set :as set]))
+(ns alda.now)
+
+(require '[alda.sound  :as sound]
+         '[alda.cli]
+         '[clojure.set :as set])
+
+; sets log level to TIMBRE_LEVEL (if set) or :warn
+(alda.cli/set-timbre-level!)
+
+(require '[alda.lisp :as lisp])
 
 (def set-up! sound/set-up!)
 


### PR DESCRIPTION
This PR turns off debug-level logging when using Alda either from `alda.cli` (i.e. the `bin/alda` script) or `alda.now`. The default log level is now `warn`, so users will still see warnings and errors.

The default log level for running tests via `boot test` is still `debug`.

In all scenarios, the log level can be overridden by setting the `TIMBRE_LEVEL` environment variable.