### PR TITLE
Extensible tuning system

### DIFF
--- a/grammar/alda.bnf
+++ b/grammar/alda.bnf
@@ -22,6 +22,7 @@ chord                   = (note | rest) subchord+
 note                    = pitch duration? <ows> slur?
 rest                    = <"r"> duration? <ows>
 
+str                     = #"\w+"
 pitch                   = !name #"[a-g][+-]*"
 duration                = note-length <ows> (tie <ows> note-length <ows>)* slur?
 note-length             = number dots?
@@ -36,21 +37,24 @@ octave-up               = <">">
 octave-down             = <"<">
 
 <global-attributes>     = <"("> <ows> global-attribute-change+ <")"> <ows>
-global-attribute-change = (global-attribute-num | global-attribute-dur)
+global-attribute-change = (global-attribute-num | global-attribute-dur | global-attribute-str)
                           <ows> <#"[,;]">? <ows>
 <global-attribute-num>  = attribute-num <"!"> <ows> number
 <global-attribute-dur>  = attribute-dur <"!"> <ows> duration
+<global-attribute-str>  = attribute-str <"!"> <ows> str
 
 <attribute-changes>     = <"("> <ows>
                           (global-attribute-change | attribute-change)+
                           <")"> <ows>
-attribute-change        = (attribute-change-num | attribute-change-dur)
+attribute-change        = (attribute-change-num | attribute-change-dur | attribute-change-str)
                           <ows> <#"[,;]">? <ows>
 <attribute-change-num>  = attribute-num <ows> number
 <attribute-change-dur>  = attribute-dur <ows> duration
+<attribute-change-str>  = attribute-str <ows> str
 <attribute-num>         = #"vol(ume)?" | #"pan(ning)?" | "tempo" |
                           #"quant(iz(e|ation))?" | #"track-vol(ume)?"
 <attribute-dur>         = "note-length"
+<attribute-str>         = #"tun(e|ing)"
 
 marker                  = <"%"> name <ows>
 at-marker               = <"@"> name <ows>

--- a/src/alda/lisp/attributes.clj
+++ b/src/alda/lisp/attributes.clj
@@ -15,6 +15,10 @@
   {:pre [(<= 0 x)]}
   (constantly (/ x 100.0)))
 
+(defn- parse-tuning [x]
+  {:pre [(#{"well" "mean"} x)]}
+  (constantly (keyword x)))
+
 (defattribute tempo
   "Current tempo. Used to calculate the duration of notes."
   :initial-val 120)
@@ -78,3 +82,9 @@
   :aliases [:pan]
   :initial-val 0.5
   :transform percentage)
+
+(defattribute tuning
+  "Current tuning."
+  :aliases [:tune]
+  :initial-val :mean
+  :transform parse-tuning)

--- a/src/alda/lisp/attributes.clj
+++ b/src/alda/lisp/attributes.clj
@@ -16,7 +16,7 @@
   (constantly (/ x 100.0)))
 
 (defn- parse-tuning [x]
-  {:pre [(#{"well" "mean"} x)]}
+  {:pre [(#{"well" "mean" "pyth"} x)]}
   (constantly (keyword x)))
 
 (defattribute tempo

--- a/src/alda/lisp/events/note.clj
+++ b/src/alda/lisp/events/note.clj
@@ -30,8 +30,8 @@
                             :instrument   instrument
                             :volume       ($volume instrument)
                             :track-volume ($track-volume instrument)
-                            :midi-note    (pitch-fn ($octave instrument) :midi true)
-                            :pitch        (pitch-fn ($octave instrument))
+                            :midi-note    (pitch-fn ($octave instrument) ($tuning instrument) :midi true)
+                            :pitch        (pitch-fn ($octave instrument) ($tuning instrument))
                             :duration     (* note-duration quant)})]
       (add-event instrument event)
       (set-last-offset instrument ($current-offset instrument))

--- a/src/alda/lisp/model/duration.clj
+++ b/src/alda/lisp/model/duration.clj
@@ -9,13 +9,9 @@
   "Converts a number, representing a note type, e.g. 4 = quarter, 8 = eighth,
    into a number of beats. Handles dots if present."
   ([number]
-    (/ 4 number))
+   (/ 4 number))
   ([number {:keys [dots]}]
-    (let [value (/ 4 number)]
-      (loop [total value, factor 0.5, dots dots]
-        (if (pos? dots)
-          (recur (+ total (* value factor)) (* factor 0.5) (dec dots))
-          total)))))
+   (* (/ 4 number) (- 2 (Math/pow 2 (- dots))))))
 
 (defn duration
   "Combines a variable number of tied note-lengths into one.

--- a/src/alda/lisp/model/pitch.clj
+++ b/src/alda/lisp/model/pitch.clj
@@ -83,7 +83,6 @@
         semitones (+ (intervals letter) offset)
         ratio (nth rational-intervals semitones)
         hz (* ratio base-hz)]
-    (prn letter (hz->midi hz))
     (if midi? (hz->midi hz) hz)))
 
 (def ^:private tunings

--- a/src/alda/lisp/model/pitch.clj
+++ b/src/alda/lisp/model/pitch.clj
@@ -60,9 +60,36 @@
         hz (* ratio base-hz)]
     (if midi? (hz->midi hz) hz)))
 
+(def ^:private rational-intervals
+  [1
+   (/ 256 243)                          ; c+
+   (/ 9 8)                              ; d
+   (/ 32 27)                             ; d+
+   (/ 81 64)                            ; e
+   (/ 4 3)                              ; f
+   (/ 729 512)                          ; f+ (augmented 4th)
+   #_(/ 1024 729)                       ; g- (diminished 5th)
+   (/ 3 2)                              ; g
+   (/ 128 81)                           ; g+ (actually a-, minor 6th)
+   (/ 27 16)                            ; a
+   (/ 16 9)                             ; a+ (minor 7th)
+   (/ 243 128)                          ; b
+   ])
+
+(defn pythagorian
+  [letter octave accidentals midi?]
+  (let [base-hz (midi->hz (midi-note :c octave))
+        offset (accidentals->offset accidentals)
+        semitones (+ (intervals letter) offset)
+        ratio (nth rational-intervals semitones)
+        hz (* ratio base-hz)]
+    (prn letter (hz->midi hz))
+    (if midi? (hz->midi hz) hz)))
+
 (def ^:private tunings
   {:well well-tempered
-   :mean mean-tempered})
+   :mean mean-tempered
+   :pyth pythagorian})
 
 (defn pitch
   "Returns a fn that will calculate the frequency in Hz, within the context

--- a/src/alda/lisp/model/pitch.clj
+++ b/src/alda/lisp/model/pitch.clj
@@ -10,24 +10,67 @@
   "Given a letter and an octave, returns the MIDI note number.
    e.g. :c, 4  =>  60"
   [letter octave]
-  (+ (intervals letter) (* octave 12) 12))
+  (+ (intervals letter) (* (inc octave) 12)))
 
 (defn- midi->hz
   "Converts a MIDI note number to the note's frequency in Hz."
   [note]
   (* 440.0 (Math/pow 2.0 (/ (- note 69.0) 12.0))))
 
+(defn- hz->midi
+  "Converts a note's frequency in Hz to its MIDI note number."
+  [hz]
+  (+ 69.0
+     (* 12.0
+        (/ (Math/log (/ hz 440.0))
+           (Math/log 2.0)))))
+
+(defn- accidentals->offset [accidentals]
+  (->> accidentals
+       (map {:flat -1, :sharp 1})
+       (remove nil?)
+       (reduce +)))
+
+(defn mean-tempered
+  [letter octave accidentals midi?]
+  (let [offset (accidentals->offset accidentals)
+        midi-note (+ (midi-note letter octave) offset)]
+    (if midi? midi-note (midi->hz midi-note))))
+
+(def ^:private werckmeister-ii
+  [1
+   (/ 256 243)
+   (* (/ 64 81) (Math/sqrt 2))
+   (/ 32 27)
+   (* (/ 256 243) (Math/pow 2 0.25))
+   (/ 4 3)
+   (/ 1024 729)
+   (* (/ 8 9) (Math/pow 8 0.25))
+   (/ 128 81)
+   (* (/ 1024 729) (Math/pow 2 0.25))
+   (/ 16 9)
+   (* (/ 128 81) (Math/pow 2 0.25))])
+
+(defn well-tempered
+  [letter octave accidentals midi?]
+  (let [base-hz (midi->hz (midi-note :c octave))
+        offset (accidentals->offset accidentals)
+        semitones (+ (intervals letter) offset)
+        ratio (nth werckmeister-ii semitones)
+        hz (* ratio base-hz)]
+    (if midi? (hz->midi hz) hz)))
+
+(def ^:private tunings
+  {:well well-tempered
+   :mean mean-tempered})
+
 (defn pitch
   "Returns a fn that will calculate the frequency in Hz, within the context
    of the octave that an instrument is in."
   [letter & accidentals]
-  (fn [octave & {:keys [midi]}]
-    (let [midi-note (reduce (fn [number accidental]
-                              (case accidental
-                                :flat  (dec number)
-                                :sharp (inc number)))
-                            (midi-note letter octave)
-                            accidentals)]
-      (if midi
-        midi-note
-        (midi->hz midi-note)))))
+  (fn [octave & rest]
+    (let [tuned? (keyword? (first rest))
+          tuning (when tuned? (first rest))
+          midi (= :midi (->> rest (take-last 2) first))
+          tuning-fn (get tunings tuning well-tempered)]
+      (tuning-fn letter octave accidentals midi))))

--- a/src/alda/lisp/model/pitch.clj
+++ b/src/alda/lisp/model/pitch.clj
@@ -68,9 +68,6 @@
   "Returns a fn that will calculate the frequency in Hz, within the context
    of the octave that an instrument is in."
   [letter & accidentals]
-  (fn [octave & rest]
-    (let [tuned? (keyword? (first rest))
-          tuning (when tuned? (first rest))
-          midi (= :midi (->> rest (take-last 2) first))
-          tuning-fn (get tunings tuning well-tempered)]
+  (fn [octave & [tuning & {:keys [midi]}]]
+    (let [tuning-fn (get tunings tuning mean-tempered)]
       (tuning-fn letter octave accidentals midi))))

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -15,6 +15,7 @@
          {:name              #(hash-map :name %)
           :nickname          #(hash-map :nickname %)
           :number            #(Integer/parseInt %)
+          :str               identity
           :voice-number      #(Integer/parseInt %)
           :tie               (constantly :tie)
           :slur              (constantly :slur)

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -86,10 +86,13 @@
     (.controlChange channel 7 (* 127 track-volume))
     (log/debugf "Playing note %s on channel %s." midi-note channel-number)
     (.setPitchBend channel bend)
+    (future (Thread/sleep 10)
+            (.setPitchBend channel bend))
     (.noteOn channel pure-note (* 127 volume))
     (Thread/sleep duration)
     (log/debug "MIDI note off:" midi-note)
-    (.noteOff channel pure-note)))
+    (.noteOff channel pure-note)
+    (.setPitchBend channel 8192)))
 
 (comment
   (defn- test-note! [note]

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -89,6 +89,22 @@
     (.noteOn channel pure-note (* 127 volume))
     (Thread/sleep duration)
     (log/debug "MIDI note off:" midi-note)
-    ;; worth setting pitch bend to zero, if we set again on next note?
-    ;; feels safer to skip rather than have subtle races..
-    (.noteOff channel midi-note)))
+    (.noteOff channel pure-note)))
+
+(comment
+  (defn- test-note! [note]
+    (play-note!
+     {:midi-note    note
+      :instrument   "piano-YUbfY"
+      :duration     300.0
+      :volume       1.0
+      :track-volume 0.75}))
+
+  (defn- test-notes! [notes]
+    (doseq [note notes]
+      (future (test-note! note))
+      (Thread/sleep 150)))
+
+  (test-notes! (range 80 82 0.05))
+
+  (test-notes! (shuffle (range 80 82 0.05))))

--- a/test/alda/test/lisp/pitch.clj
+++ b/test/alda/test/lisp/pitch.clj
@@ -8,11 +8,26 @@
     (part* "piano")
     (run-tests)))
 
+(defn- =% [x y]
+  (< x y (+ x 0.01)))
+
 (deftest pitch-tests
   (testing "pitch converts a note in a given octave to frequency in Hz"
     (is (== 440 ((pitch :a) 4)))
     (is (== 880 ((pitch :a) 5)))
-    (is (< 261 ((pitch :c) 4) 262)))
+    (is (=% 261.62 ((pitch :c) 4))))
+  (testing "pitch converts a note in a given octave to a MIDI note"
+    (is (= 69 ((pitch :a) 4 :default :midi true)))
+    (is (= 81 ((pitch :a) 5 :default :midi true)))
+    (is (= 60 ((pitch :c) 4 :default :midi true))))
+  (testing "pitch converts using a well-tempered tuning"
+    (is (=% 437.02 ((pitch :a) 4 :well)))
+    (is (=% 874.05 ((pitch :a) 5 :well)))
+    (is (=% 261.62 ((pitch :c) 4 :well))))
+  (testing "pitch converts well-tempered tuning notes to MIDI also"
+    (is (=% 68.88 ((pitch :a) 4 :well :midi true)))
+    (is (=% 80.88 ((pitch :a) 5 :well :midi true)))
+    (is (= 60.0 ((pitch :c) 4 :well :midi true))))
   (testing "flats and sharps"
     (is (>  ((pitch :c :sharp) 4) ((pitch :c) 4)))
     (is (>  ((pitch :c) 5) ((pitch :c :sharp) 4)))


### PR DESCRIPTION
Played around a bit with tuning, related to #45 

Certainly wouldn't expect this merged as is, don't think the syntax is correct at all.

1. Need more power and extensibility for setting tuning than just a name - eg. tempering around another key, or brute force setting each note

2. Being able to provide wholesale new tuning systems in plugins, eg. that have irregular, asymmetric or non-abelian treatment of accidentals, or octaves that don't double frequency (like a skewed mean-temperament that preserves the 3:2 5th)

3. Introducing tuning parameters, and making the tuning map extensible are both simple enough (pass whole context to tuning, and maybe have a `defattribute` style macro for tunings) - but what seems slightly harder is designing the BNF grammar to be flexible enough, but still helpful.

  Wondering about the maintenance and DRY side of having all these different attributes and their types in the grammar. Thinking that a free-for-all `(<attribute-name> [^)]*)` grammar plus dynamic validation during parsing could be a better fit - data passed to `defattribute` macro, and potentially `deftuning` macro too, could be used to still validate, but suddenly the system is far more open.

4. Lastly, I couldn't find any suitable Beethoven (7th would be great) in alda format to test this tuning out with - should we raise another issue for that? :violin: 

5. Have no idea where to start notating Harry Parch or Terry Riley into alda (or how they even notate things traditionally). This sounds like lots of fun, and I'm keen to try or die learning