### PR TITLE
Support "from" and "to" for playing

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -51,6 +51,7 @@
                        alda.lisp.pitch-test
                        alda.lisp.score-test
                        alda.lisp.voices-test
+                       alda.util-test
                        }})
 
 (deftask alda

--- a/src/alda/cli.clj
+++ b/src/alda/cli.clj
@@ -49,12 +49,16 @@
    ; TODO: implement smart buffering and remove the buffer options
    p pre-buffer  MS  int  "The number of milliseconds of lead time for buffering. (default: 0)"
    P post-buffer MS  int  "The number of milliseconds to keep the synth open after the score ends. (default: 1000)"
-   s stock           bool "Use the default MIDI soundfont of your JVM, instead of FluidR3."]
+   s stock           bool "Use the default MIDI soundfont of your JVM, instead of FluidR3."
+   F from        POS str  "Position to start playback from"
+   T to          POS str  "Position to end playback at"]
   (require '[alda.lisp]
            '[instaparse.core])
   (binding [alda.sound.midi/*midi-soundfont* (when-not stock (fluid-r3!))
             alda.sound/*play-opts* {:pre-buffer  (or pre-buffer 0)
                                     :post-buffer (or post-buffer 1000)
+                                    :from        from
+                                    :to          to
                                     :one-off?    true}]
     (if-not (or file code)
       (play "--help")

--- a/src/alda/lisp/score.clj
+++ b/src/alda/lisp/score.clj
@@ -18,7 +18,7 @@
 (defn score*
   []
   (letfn [(init [var val] (alter-var-root var (constantly val)))]
-    (init #'*score-text* "") 
+    (init #'*score-text* "")
     (init #'*events* {:start {:offset (AbsoluteOffset. 0), :events []}})
     (init #'*global-attributes* {})
     (init #'*instruments* {})
@@ -31,16 +31,16 @@
    offsets."
   [events-map]
   (into #{}
-    (mapcat (fn [[_ {:keys [offset events]}]]
-              (for [event events]
-                (update-in event [:offset] absolute-offset)))
-            events-map)))
+        (mapcat (fn [[_ {:keys [offset events]}]]
+                  (for [event events]
+                    (update-in event [:offset] absolute-offset))))
+        events-map))
 
 (defn markers [events-map]
   (into {}
-    (map (fn [[marker-name {marker-offset :offset}]]
-           [marker-name (absolute-offset marker-offset)])
-         events-map)))
+        (map (fn [[marker-name {marker-offset :offset}]]
+               [marker-name (absolute-offset marker-offset)]))
+        events-map))
 
 (defn score-map
   []

--- a/src/alda/repl/core.clj
+++ b/src/alda/repl/core.clj
@@ -32,8 +32,8 @@
               (let [parsed (parse-with-start-rule ctx alda-code)]
                 (if (insta/failure? parsed)
                   (try-ctxs ctxs)
-                  (do 
-                    (alter-var-root #'*parsing-context* (constantly ctx)) 
+                  (do
+                    (alter-var-root #'*parsing-context* (constantly ctx))
                     parsed)))
               (log/error "Invalid Alda syntax.")))]
     (try-ctxs [:music-data :part :score])))

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -2,7 +2,7 @@
   (:require [alda.sound.midi :as    midi]
             [overtone.at-at  :refer (mk-pool now at)]
             [taoensso.timbre :as    log]
-            [alda.util       :refer (check-for)]))
+            [alda.util       :refer [check-for parse-time pdoseq parse-position]]))
 
 (def ^:dynamic *active-audio-types* #{})
 
@@ -15,7 +15,7 @@
 
 (defmethod set-up-audio-type! :default
   [audio-type & [score]]
-  (log/errorf "No implementation of set-up-audio-type! defined for type %s" 
+  (log/errorf "No implementation of set-up-audio-type! defined for type %s"
               audio-type))
 
 (defmethod set-up-audio-type! :midi
@@ -27,9 +27,9 @@
    e.g. for MIDI, create and open a MIDI synth."
   [audio-type & [score]]
   (if (coll? audio-type)
-    (doall 
-      (pmap #(set-up! % score) audio-type))
-    (when-not (set-up? audio-type) 
+    (pdoseq [a-t audio-type]
+      (set-up! a-t score))
+    (when-not (set-up? audio-type)
       (set-up-audio-type! audio-type score)
       (alter-var-root #'*active-audio-types* conj audio-type))))
 
@@ -40,7 +40,7 @@
 
 (defmethod refresh-audio-type! :default
   [audio-type & [score]]
-  (log/errorf "No implementation of refresh-audio-type! defined for type %s" 
+  (log/errorf "No implementation of refresh-audio-type! defined for type %s"
               audio-type))
 
 (defmethod refresh-audio-type! :midi
@@ -54,9 +54,9 @@
    added to the score between calls to `play!`, when using Alda live.)"
   [audio-type & [score]]
   (if (coll? audio-type)
-    (doall 
-      (pmap #(refresh! % score) audio-type))
-    (when (set-up? audio-type) 
+    (pdoseq [a-t audio-type]
+      (refresh! a-t score))
+    (when (set-up? audio-type)
       (refresh-audio-type! audio-type score))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -77,11 +77,24 @@
    e.g. for MIDI, close the MIDI synth."
   [audio-type & [score]]
   (if (coll? audio-type)
-    (doall 
-      (pmap #(tear-down! % score) audio-type))
-    (when (set-up? audio-type) 
+    (pdoseq [a-t audio-type]
+      (tear-down! a-t score))
+    (when (set-up? audio-type)
       (tear-down-audio-type! audio-type score)
       (alter-var-root #'*active-audio-types* disj audio-type))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn shift-events
+  [events offset cut-off]
+  (let [offset  (or offset 0)
+        cut-off (when cut-off (- cut-off offset))
+        keep?   (if cut-off
+                  #(and (<= 0 %) (> cut-off %))
+                  #(<= 0 %))]
+    (sequence (comp (map #(update-in % [:offset] - offset))
+                    (filter (comp keep? :offset)))
+              events)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -121,38 +134,65 @@
 
 (def ^:dynamic *play-opts* {})
 
-; TODO: control where to start and stop playing using the start & end keys
+(defmacro with-play-opts
+  "Apply `opts` as overrides to *play-opts* when executing `body`"
+  [opts & body]
+  `(binding [*play-opts* (merge *play-opts* ~opts)]
+     ~@body))
+
+(defn- lookup-time [markers pos]
+  (let [pos (if (string? pos)
+              (parse-position pos)
+              pos)]
+    (cond (keyword? pos)
+          (or (markers (name pos))
+              (throw (Exception. (str "Marker " pos " not found."))))
+
+          (or (number? pos) (nil? pos))
+          pos
+
+          :else
+          (throw (Exception. (str "Do not support " (type pos) " as a play time."))))))
+
+(defn start-finish-times [{:keys [from to]} markers]
+  (map (partial lookup-time markers) [from to]))
+
 (defn play!
   "Plays an Alda score, optionally from given start/end marks.
-   
+
    Returns a function that, when called mid-playback, will stop any further
    events from playing."
-  [{:keys [events instruments] :as score}]
-  (let [{:keys [start end pre-buffer post-buffer one-off? async?]} *play-opts*
+  [{:keys [events markers instruments] :as score}]
+  (let [{:keys [pre-buffer post-buffer one-off? async?]} *play-opts*
         audio-types (determine-audio-types score)
         _           (set-up! audio-types score)
         _           (refresh! audio-types score)
         pool        (mk-pool)
         playing?    (atom true)
-        start       (+ (now) (or pre-buffer 0))]
-    (doall (pmap (fn [{:keys [offset instrument] :as event}]
-                   (let [instrument (-> instrument instruments)]
-                     (at (+ start offset) 
-                         #(when @playing? 
-                            (play-event! event instrument)) 
-                         pool)))
-                 events))
+        begin       (+ (now) (or pre-buffer 0))
+        [start end] (start-finish-times *play-opts* markers)
+        events      (shift-events events start end)
+        duration    (- (or end (score-length score))
+                       (or start 0))]
+    (pdoseq [{:keys [offset instrument] :as event} events
+            :let [instrument (-> instrument instruments)]]
+      (at (+ begin offset)
+          #(when @playing?
+             (play-event! event instrument))
+          pool))
+
     (when-not async?
       ; block until the score is done playing
-      (Thread/sleep (+ (score-length score) 
+      (Thread/sleep (+ duration
                        (or pre-buffer 0)
                        (or post-buffer 0))))
     (when one-off? (tear-down! audio-types score))
     #(reset! playing? false)))
 
 (defn make-wav!
-  "Parses an input file and saves the resulting sound data as a wav file, 
+  "Parses an input file and saves the resulting sound data as a wav file,
    using the specified options."
   [input-file output-file {:keys [start end]}]
   (let [target-file (check-for output-file)]
-    (comment "To do.")))
+    ;; TODO
+    nil))

--- a/src/alda/util.clj
+++ b/src/alda/util.clj
@@ -3,6 +3,50 @@
             [taoensso.timbre :as timbre])
   (:import (java.io File)))
 
+(defmacro pdoseq
+  "A fairly efficient hybrid of `doseq` and `pmap`"
+  [binding & body]
+  `(doseq ~binding
+     (future ~@body)))
+
+(defn strip-nil-values
+  "Strip `nil` values from a map."
+  [hsh]
+  (into (empty hsh) (remove (comp nil? last)) hsh))
+
+(defn parse-str-opts
+  "Transform string based keyword arguments into a regular map, eg.
+   IN:  \"from 0:20 to :third-movement some-junk-at-end\"
+   OUT: {:from  \"0:20\"
+         :to \":third-movement\"}"
+  [opts-str]
+  (let [pairs (partition 2 (str/split opts-str #"\s"))]
+    (into {} (map (fn [[k v]] [(keyword k) v])) pairs)))
+
+(defn parse-time
+  "Convert a human readable duration into milliseconds, eg. \"02:31\" => 151 000"
+  [time-str]
+  (let [[s m h] (as-> (str/split time-str #":") x
+                      (reverse x)
+                      (map #(Double/parseDouble %) x)
+                      (concat x [0 0 0]))]
+    (* (+ (* 60 (+ (* 60 h) m)) s) 1000)))
+
+(def ^:private duration-regex
+  #"^(\d+(\.\d+)?)(:\d+(\.\d+)?)*$")
+
+(defn parse-position
+  "Convert a string denoting a position in a song into the appropriate type.
+   For explicit timepoints this is a double denoting milliseconds, and for
+   markers this is a keyword."
+  [position-str]
+  (when position-str
+    (if (re-find duration-regex position-str)
+      (parse-time position-str)
+      (if (.startsWith position-str ":")
+        (keyword (subs position-str 1))
+        (keyword position-str)))))
+
 (defn set-timbre-level!
   []
   (timbre/set-level! (if-let [level (System/getenv "TIMBRE_LEVEL")]

--- a/src/alda/util.clj
+++ b/src/alda/util.clj
@@ -3,13 +3,12 @@
             [taoensso.timbre :as timbre])
   (:import (java.io File)))
 
+;; FIXME
 (defmacro pdoseq
   "A fairly efficient hybrid of `doseq` and `pmap`"
   [binding & body]
-  #_`(doseq ~binding
-     (future ~@body))
-  (prn `(doall (pmap #(let [~(first binding) %] ~@body) ~(second binding) )))
-  `(doall (pmap #(let [~(first binding) %] ~@body) ~(second binding) )))
+  #_`(doseq ~binding (future @body))
+  #_`(doall (pmap #(let [~(first binding) %] ~@body) ~(second binding))))
 
 (defn strip-nil-values
   "Strip `nil` values from a map."

--- a/src/alda/util.clj
+++ b/src/alda/util.clj
@@ -6,8 +6,10 @@
 (defmacro pdoseq
   "A fairly efficient hybrid of `doseq` and `pmap`"
   [binding & body]
-  `(doseq ~binding
-     (future ~@body)))
+  #_`(doseq ~binding
+     (future ~@body))
+  (prn `(doall (pmap #(let [~(first binding) %] ~@body) ~(second binding) )))
+  `(doall (pmap #(let [~(first binding) %] ~@body) ~(second binding) )))
 
 (defn strip-nil-values
   "Strip `nil` values from a map."

--- a/test/alda/util_test.clj
+++ b/test/alda/util_test.clj
@@ -1,0 +1,21 @@
+(ns alda.util-test
+  (:require [clojure.test :refer :all]
+            [alda.util :refer :all]))
+
+(deftest strip-nil-values-test
+  (is (= {:a 1 :c 3} (strip-nil-values {:a 1 :b nil :c 3 :d nil}))))
+
+(deftest parse-str-opts-test
+  (is (= {:a "1" :b "2"} (parse-str-opts "a 1 b 2 c"))))
+
+(deftest parse-time-test
+  (is (== 3000    (parse-time "3")))
+  (is (== 1500    (parse-time "1.5")))
+  (is (== 1750000 (parse-time "29:10")))
+  (is (== 605900  (parse-time "10:05.9")))
+  (is (== 7264000 (parse-time "02:01:04")))
+  (is (== 3723300 (parse-time "01:02:03.30"))))
+
+(deftest parse-position-test
+  (is (= :third-movement (parse-position ":third-movement")))
+  (is (== 143000 (parse-position "02:23"))))


### PR DESCRIPTION
Not quite done with this yet, but perhaps ready for feedback.

There are some performance-oriented things here, like making some functions lazy, a lower-overhead trick than `(doall (pmap ..))` and using transducers in some places.

Will be back this evening to finish this off - supporting labels, typing in with CLI and REPL commands, and adding tests