### PR TITLE
Reloadable REPL

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -19,7 +19,7 @@
          '[alda.cli]
          '[str-to-argv :refer (split-args)])
 
-; version number is stored in alda.version 
+; version number is stored in alda.version
 (bootlaces! alda.version/-version-)
 
 (task-options!
@@ -50,11 +50,17 @@
 
 (deftask alda
   "Run Alda CLI tasks.
-   
-   Whereas running `bin/alda <cmd> <args>` will use the latest deployed 
+
+   Whereas running `bin/alda <cmd> <args>` will use the latest deployed
    version of Alda, running this task (`boot alda -x '<cmd> <args>'`)
    will use the current (local) version of this repo."
   [x execute ARGS str "The Alda CLI task and args as a single string."]
-  (when execute
-    (let [cli-args (split-args execute)]
-      (apply (resolve 'alda.cli/-main) cli-args))))
+  (fn [next-task]
+    (fn [fileset]
+      (require '[alda.version] :reload-all)
+      (require '[alda.repl] :reload-all)
+      ;(require '[alda.cli] :reload-all)
+      (when execute
+        (let [cli-args (split-args execute)]
+          (apply (resolve 'alda.cli/-main) cli-args)))
+      (next-task fileset))))


### PR DESCRIPTION
Having a REPL that live-loads changes made to the source base, without depending on piggy-backing on a Clojure REPL, would be exciting and accessible for new users. It would also be invaluable with the server.

It could be as simple as `boot watch alda -x repl`, and there could be hash-bang sugar for that.

So far this is just the first tiny step.. having the alda task run via the regular boot lifecycle instead of launching statically (haven't measured overhead in start-up time, hopefully negligible). The benefit of this is that the REPL will automatically relaunch with changes.. but you have to manually close the old REPL first. On the plus-side the relaunch is basically instantaneous.

Now for the bad news sandwich - the relaunch crashes: `javax.sound.midi.InvalidMidiDataException: cannot get soundbank from stream`

Haven't spent much time on this, might be pretty low hanging. 

Some ideas to take this forward:

- [x] Don't crash from synth contention (blacklisted namespace? run this bit in separate singleton pod?)
- [ ] Don't block in the task - catch code changes immediately
- [ ] Refresh currently running REPL, and give some on-screen feedback (success / warning / fail)
- [ ] Don't actually relaunch on kill, in fact kill the `watch`-er to save double-quit
- [ ] Don't lose any state (perhaps by blacklisting namespaces for reload, or serializing and restoring it)