### PR TITLE
Include bar-lines in the parse tree

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -33,6 +33,7 @@
                  "url" "http://www.eclipse.org/legal/epl-v10.html"}}
   jar {:main 'alda.cli}
   test {:namespaces '#{alda.parser.attributes-test
+                       alda.parser.barlines-test
                        alda.parser.comments-test
                        alda.parser.duration-test
                        alda.parser.events-test

--- a/grammar/alda.bnf
+++ b/grammar/alda.bnf
@@ -10,7 +10,7 @@ nickname                = <"\""> acceptable-name <"\"">
 
 <music-data>            = (voices | event)*
 <event>                 = chord | note | rest | octave-change |
-                          attribute-changes | marker | at-marker
+                          attribute-changes | marker | at-marker | barline
 voices                  = voice+ (<voice-zero> | <#"\z">)
 voice                   = voice-number event*
 voice-number            = <"V"> #"[1-9]\d*" <":"> <ows>
@@ -55,10 +55,11 @@ attribute-change        = (attribute-change-num | attribute-change-dur)
 marker                  = <"%"> name <ows>
 at-marker               = <"@"> name <ows>
 
+barline                 = <"|"> <ows>
+
 ows                     = (#"\s" | comment)*
 
-comment                 = long-comment | short-comment | barline
+comment                 = long-comment | short-comment
 long-comment            = "(*" inside-long-comment* "*)"
 inside-long-comment     = !("(*" | "*)") #".|\n|\r" | long-comment
 short-comment           = "#" #".*" #"(\n|\r|$)+"
-barline                 = "|"

--- a/src/alda/lisp/events/barline.clj
+++ b/src/alda/lisp/events/barline.clj
@@ -1,0 +1,6 @@
+(ns alda.lisp.events.barline)
+(in-ns 'alda.lisp)
+
+; barlines, at least currently, do nothing when evaluated in alda.lisp
+
+(defn barline [] nil)

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -6,6 +6,12 @@
 (def ^:private alda-parser
   (insta/parser (io/resource "alda.bnf")))
 
+(defn parse-tree
+  "Returns the intermediate parse tree resulting from parsing a string of Alda
+   code."
+  [alda-code]
+  (alda-parser alda-code))
+
 (defn parse-input
   "Parses a string of Alda code and turns it into Clojure code."
   [alda-code]
@@ -43,6 +49,7 @@
           :voices            #(list* 'alda.lisp/voices %&)
           :marker            #(list 'alda.lisp/marker (:name %))
           :at-marker         #(list 'alda.lisp/at-marker (:name %))
+          :barline           #(list 'alda.lisp/barline)
           :calls             (fn [& calls]
                                (let [names    (vec (keep :name calls))
                                      nickname (some :nickname calls)]

--- a/src/alda/version.clj
+++ b/src/alda/version.clj
@@ -1,4 +1,4 @@
 (ns alda.version)
 
-(def ^:const -version- "0.6.0")
+(def ^:const -version- "0.6.1")
 

--- a/test/alda/parser/barlines_test.clj
+++ b/test/alda/parser/barlines_test.clj
@@ -1,0 +1,39 @@
+(ns alda.parser.barlines-test
+  (:require [clojure.test :refer :all]
+            [alda.test-helpers :refer (test-parse)]))
+
+(def alda-code
+  "violin: c d | e f | g a")
+
+(def parse-tree
+  [:score
+   [:part
+    [:calls [:name "violin"]]
+    [:note [:pitch "c"]]
+    [:note [:pitch "d"]]
+    [:barline]
+    [:note [:pitch "e"]]
+    [:note [:pitch "f"]]
+    [:barline]
+    [:note [:pitch "g"]]
+    [:note [:pitch "a"]]]])
+
+(def alda-lisp-code
+  '(alda.lisp/score
+     (alda.lisp/part {:names ["violin"]}
+       (alda.lisp/note (alda.lisp/pitch :c))
+       (alda.lisp/note (alda.lisp/pitch :d))
+       (alda.lisp/barline)
+       (alda.lisp/note (alda.lisp/pitch :e))
+       (alda.lisp/note (alda.lisp/pitch :f))
+       (alda.lisp/barline)
+       (alda.lisp/note (alda.lisp/pitch :g))
+       (alda.lisp/note (alda.lisp/pitch :a)))))
+
+(deftest barline-tests
+  (testing "bar-lines are included in the parse tree"
+    (is (= [:barline] (test-parse :barline "|" {:tree true})))
+    (is (= parse-tree (test-parse :score alda-code {:tree true}))))
+  (testing "bar-lines are included in alda.lisp code (even though they don't do anything)"
+    (is (= alda-lisp-code (test-parse :score alda-code)))))
+

--- a/test/alda/test_helpers.clj
+++ b/test/alda/test_helpers.clj
@@ -5,11 +5,14 @@
             [clojure.java.io :as io]))
 
 (defn test-parse
-  "Uses instaparse's partial parse mode to parse individual pieces of a score."
-  [start input]
+  "Uses instaparse's partial parse mode to parse individual pieces of a score.
+
+   If `tree` is true, returns the intermediate parse tree before it would be
+   transformed into alda.lisp code."
+  [start input & [{:keys [tree]}]]
   (with-redefs [alda.parser/alda-parser
                 #((insta/parser (io/resource "alda.bnf")) % :start start)]
-    (parse-input input)))
+    ((if tree parse-tree parse-input) input)))
 
 (defn get-instrument
   "Returns the first instrument in *instruments* whose id starts with inst-name."


### PR DESCRIPTION
This is a change that will help facilitate visually rendering scores. Bar lines are now parsed as a [:barline] node, which is transformed to a call to (alda.lisp/barline), which does NOTHING. IT DOES ABSOLUTELY NOTHING.