### PR TITLE
Allow tying across barlines

### DIFF
--- a/grammar/alda.bnf
+++ b/grammar/alda.bnf
@@ -23,7 +23,8 @@ note                    = pitch duration? <ows> slur?
 rest                    = <"r"> duration? <ows>
 
 pitch                   = !name #"[a-g][+-]*"
-duration                = note-length <ows> (tie <ows> note-length <ows>)* slur?
+duration                = note-length <ows> barline? <ows> subduration* slur?
+<subduration>           = tie <ows> barline? <ows> note-length <ows> barline? <ows>
 note-length             = number dots?
 number                  = #"-?[0-9]+"
 dots                    = #"\.+"

--- a/src/alda/cli.clj
+++ b/src/alda/cli.clj
@@ -4,7 +4,7 @@
             [boot.core       :refer (merge-env!)]
             [clojure.string  :as    str]
             [clojure.pprint  :refer (pprint)]
-            [alda.parser     :refer (parse-input)]
+            [alda.parser     :refer (parse-input parse-tree)]
             [alda.version    :refer (-version-)]
             [alda.sound]))
 
@@ -21,20 +21,26 @@
   "Parse some Alda code and print the results to the console."
   [f file FILE str  "The path to a file containing Alda code to parse."
    c code CODE str  "The string of Alda code to parse."
+   t tree      bool "Show the intermediate parse tree."
    l lisp      bool "Parse into alda.lisp code."
    m map       bool "Evaluate the score and show the resulting instruments/events map."]
   (if-not (or file code)
     (parse "--help")
-    (let [alda-lisp-code (parse-input (if code code (slurp file)))]
+    (let [input (if code code (slurp file))
+          alda-lisp-code (parse-input input)]
       (when (instaparse.core/failure? alda-lisp-code)
         (pprint alda-lisp-code)
         (System/exit 1))
+      (when tree
+        (pprint (parse-tree input))
+        (println))
       (when lisp
-        (pprint alda-lisp-code))
+        (pprint alda-lisp-code)
+        (println))
       (when map
         (require 'alda.lisp)
-        (println)
-        (pprint (eval alda-lisp-code))))))
+        (pprint (eval alda-lisp-code))
+        (println)))))
 
 (defclifn ^:alda-task play
   "Parse some Alda code and play the resulting score."

--- a/src/alda/lisp/model/duration.clj
+++ b/src/alda/lisp/model/duration.clj
@@ -20,13 +20,18 @@
 (defn duration
   "Combines a variable number of tied note-lengths into one.
 
+   Barlines can be inserted inside of a duration -- these currently serve a
+   purpose in the parse tree only, and evaluate to `nil` in alda.lisp. This
+   function ignores barlines by removing the nils.
+
    A slur may appear as the final argument of a duration, making the current
    note legato (effectively slurring it into the next).
 
    Returns a map containing a duration-fn, which gives the duration in ms when
    provide with a tempo, and whether or not the note is slurred."
   [& components]
-  (let [[note-lengths slurred] (if (= (last components) :slur)
+  (let [components (remove nil? components)
+        [note-lengths slurred] (if (= (last components) :slur)
                                  (conj [(drop-last components)] true)
                                  (conj [components] false))
         beats (apply + note-lengths)]

--- a/src/alda/version.clj
+++ b/src/alda/version.clj
@@ -1,4 +1,4 @@
 (ns alda.version)
 
-(def ^:const -version- "0.6.2")
+(def ^:const -version- "0.6.3")
 

--- a/test/alda/lisp/duration_test.clj
+++ b/test/alda/lisp/duration_test.clj
@@ -26,6 +26,12 @@
       (is (== 500 (duration-fn 120))))
     (let [{:keys [duration-fn]} (duration (note-length 4 {:dots 1}))]
       (is (== 750 (duration-fn 120)))))
+  (testing "barlines don't break duration"
+    (let [{:keys [duration-fn]} (duration (note-length 4)
+                                          (barline)
+                                          (note-length 4)
+                                          :slur)]
+      (is (== 2000 (duration-fn 60)))))
   (testing "quantization quantizes note durations"
     (set-attributes :tempo 120 :quant 100)
     (is (== 500

--- a/test/alda/parser/barlines_test.clj
+++ b/test/alda/parser/barlines_test.clj
@@ -2,10 +2,10 @@
   (:require [clojure.test :refer :all]
             [alda.test-helpers :refer (test-parse)]))
 
-(def alda-code
+(def alda-code-1
   "violin: c d | e f | g a")
 
-(def parse-tree
+(def parse-tree-1
   [:score
    [:part
     [:calls [:name "violin"]]
@@ -18,7 +18,7 @@
     [:note [:pitch "g"]]
     [:note [:pitch "a"]]]])
 
-(def alda-lisp-code
+(def alda-lisp-code-1
   '(alda.lisp/score
      (alda.lisp/part {:names ["violin"]}
        (alda.lisp/note (alda.lisp/pitch :c))
@@ -30,10 +30,52 @@
        (alda.lisp/note (alda.lisp/pitch :g))
        (alda.lisp/note (alda.lisp/pitch :a)))))
 
+(def alda-code-2
+  "marimba: c1|~1|~1~|1|~1~|2.")
+
+(def parse-tree-2
+  [:score
+    [:part
+      [:calls [:name "marimba"]]
+      [:note [:pitch "c"]
+             [:duration
+               [:note-length [:number "1"]]
+               [:barline]
+               [:note-length [:number "1"]]
+               [:barline]
+               [:note-length [:number "1"]]
+               [:barline]
+               [:note-length [:number "1"]]
+               [:barline]
+               [:note-length [:number "1"]]
+               [:barline]
+               [:note-length [:number "2"] [:dots "."]]]]]])
+
+(def alda-lisp-code-2
+  '(alda.lisp/score
+     (alda.lisp/part {:names ["marimba"]}
+       (alda.lisp/note 
+         (alda.lisp/pitch :c)
+         (alda.lisp/duration
+           (alda.lisp/note-length 1)
+           (alda.lisp/barline)
+           (alda.lisp/note-length 1)
+           (alda.lisp/barline)
+           (alda.lisp/note-length 1)
+           (alda.lisp/barline)
+           (alda.lisp/note-length 1)
+           (alda.lisp/barline)
+           (alda.lisp/note-length 1)
+           (alda.lisp/barline)
+           (alda.lisp/note-length 2 {:dots 1}))))))
+
 (deftest barline-tests
-  (testing "bar-lines are included in the parse tree"
+  (testing "barlines are included in the parse tree"
     (is (= [:barline] (test-parse :barline "|" {:tree true})))
-    (is (= parse-tree (test-parse :score alda-code {:tree true}))))
-  (testing "bar-lines are included in alda.lisp code (even though they don't do anything)"
-    (is (= alda-lisp-code (test-parse :score alda-code)))))
+    (is (= parse-tree-1 (test-parse :score alda-code-1 {:tree true}))))
+  (testing "barlines are included in alda.lisp code (even though they don't do anything)"
+    (is (= alda-lisp-code-1 (test-parse :score alda-code-1))))
+  (testing "notes can be tied over barlines"
+    (is (= parse-tree-2 (test-parse :score alda-code-2 {:tree true})))
+    (is (= alda-lisp-code-2 (test-parse :score alda-code-2)))))
 


### PR DESCRIPTION
Fixes #97.

Incidentally, this PR also adds a `--tree` flag to the `alda parse` task, which prints the intermediate AST when set.