### PR TITLE
Simplify CLJ expression parser

### DIFF
--- a/grammar/alda.bnf
+++ b/grammar/alda.bnf
@@ -59,10 +59,11 @@ clj-string              = <"\""> inside-clj-string* <"\"">
                              "#{" | 
                              "{" | "}" | 
                              "\"" | "\\" )
-                          #".|\n|\r" | clj-expr | clj-string | clj-character |
+                          #".|\n|\r" | clj-list | clj-string | clj-character |
                           clj-vector | clj-map | clj-set
 
 clj-expr                = <"("> inside-clj-coll* <")"> <ows>
+clj-list                = <"("> inside-clj-coll* <")">
 clj-vector              = <"["> inside-clj-coll* <"]">
 clj-set                 = <"#{"> inside-clj-coll* <"}">
 clj-map                 = <"{"> inside-clj-coll* <"}">

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -54,6 +54,7 @@
                              (if (empty? current-str)
                                [results i current-str]
                                [(update results i conj current-str) i ""]))
+        conj* (fn [xs x] (concat xs (list x)))
         exprs (loop [results [[]]
                      i 0
                      current-str ""
@@ -69,12 +70,12 @@
                                                                   i
                                                                   current-str)
                                               [0 i]
-                                              conj (:value expr))
+                                              conj* (:value expr))
                         (update-in (add-if-appropriate results
                                                        i
                                                        current-str)
                                    [0 i]
-                                   conj expr))]
+                                   conj* expr))]
                   (if (seq more)
                     (recur results i current-str more)
                     (first (add-if-appropriate results i current-str)))))

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -106,6 +106,7 @@
        (insta/transform
          {:clj-character     #(StringHack. (str \\ %))
           :clj-string        #(StringHack. (str \" (apply str %&) \"))
+          :clj-list          #(read-clj-coll %& "(%s)")
           :clj-vector        #(read-clj-coll %& "[%s]")
           :clj-map           #(read-clj-coll %& "{%s}")
           :clj-set           #(read-clj-coll %& "#{%s}")

--- a/test/alda/parser/clj_exprs_test.clj
+++ b/test/alda/parser/clj_exprs_test.clj
@@ -83,3 +83,14 @@
            '(clojure.core/prn #{1 2 #{3 4} 5})))
     (is (= (test-parse :clj-expr "(prn (+ 1 [2 {3 #{4 5}}]))")
            '(clojure.core/prn (clojure.core/+ 1 [2 {3 #{4 5}}]))))))
+
+(deftest quirky-tests
+  (testing "parameter order in subsequent expressions gets weird if there are data structures"
+    (is (= (test-parse :clj-expr "(prn [1, 2], prn [3, 4])")
+           '(do (clojure.core/prn [1 2])
+                (clojure.core/prn [3 4])))))
+  (testing "commas / semis should not get expanded in outer expressions"
+    (is (= (test-parse :clj-expr "(prn [1 2], prn (+ 1, 2))")
+           '(do (clojure.core/prn [1 2])
+                (clojure.core/prn
+                 (clojure.core/+ 1 2)))))))


### PR DESCRIPTION
Looks like it works, but perhaps too naive? Certainly seems simpler :wink: 

Watch out, this contains #105. For a clean diff just look at e41ca1c8c7473052e2eaeb90a2b2492dc28b461e