### PR TITLE
Replaced existing FluidR3 installation mechanism with a dedicated script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Alda
 
-Pull requests are warmly welcomed. Please feel free to take on whatever [issue](https://github.com/alda-lang/alda/issues) interests you. 
+Pull requests are warmly welcomed. Please feel free to take on whatever [issue](https://github.com/alda-lang/alda/issues) interests you.
 
 ## Instructions
 
@@ -30,24 +30,24 @@ Code is given to the parser, resulting in a parse tree:
 ```clojure
 alda.parser=> (alda-parser "piano: c8 e g c1/f/a")
 
-[:score 
-  [:part 
-    [:calls [:name "piano"]] 
-    [:note 
-      [:pitch "c"] 
-      [:duration 
-        [:note-length [:number "8"]]]] 
-    [:note 
-      [:pitch "e"]] 
-    [:note 
-      [:pitch "g"]] 
-    [:chord 
-      [:note 
-        [:pitch "c"] 
-        [:duration [:note-length [:number "1"]]]] 
-      [:note 
-        [:pitch "f"]] 
-      [:note 
+[:score
+  [:part
+    [:calls [:name "piano"]]
+    [:note
+      [:pitch "c"]
+      [:duration
+        [:note-length [:number "8"]]]]
+    [:note
+      [:pitch "e"]]
+    [:note
+      [:pitch "g"]]
+    [:chord
+      [:note
+        [:pitch "c"]
+        [:duration [:note-length [:number "1"]]]]
+      [:note
+        [:pitch "f"]]
+      [:note
         [:pitch "a"]]]]]
 ```
 
@@ -58,22 +58,22 @@ Clojure is a Lisp; in Lisp, code is data and data is code. This powerful concept
 ```clojure
 alda.parser=> (parse-input "piano: c8 e g c1/f/a")
 
-(alda.lisp/score 
-  (alda.lisp/part {:names ["piano"]} 
-    (alda.lisp/note 
-      (alda.lisp/pitch :c) 
-      (alda.lisp/duration (alda.lisp/note-length 8))) 
-    (alda.lisp/note 
-      (alda.lisp/pitch :e)) 
-    (alda.lisp/note 
-      (alda.lisp/pitch :g)) 
-    (alda.lisp/chord 
-      (alda.lisp/note 
-        (alda.lisp/pitch :c) 
-        (alda.lisp/duration (alda.lisp/note-length 1))) 
-      (alda.lisp/note 
-        (alda.lisp/pitch :f)) 
-      (alda.lisp/note 
+(alda.lisp/score
+  (alda.lisp/part {:names ["piano"]}
+    (alda.lisp/note
+      (alda.lisp/pitch :c)
+      (alda.lisp/duration (alda.lisp/note-length 8)))
+    (alda.lisp/note
+      (alda.lisp/pitch :e))
+    (alda.lisp/note
+      (alda.lisp/pitch :g))
+    (alda.lisp/chord
+      (alda.lisp/note
+        (alda.lisp/pitch :c)
+        (alda.lisp/duration (alda.lisp/note-length 1)))
+      (alda.lisp/note
+        (alda.lisp/pitch :f))
+      (alda.lisp/note
         (alda.lisp/pitch :a)))))
 ```
 
@@ -172,7 +172,7 @@ Because `alda.lisp` is a Clojure DSL, it's possible to use it to build scores wi
 
 ### alda.sound
 
-The `alda.sound` namespace handles the implementation details of playing the score. 
+The `alda.sound` namespace handles the implementation details of playing the score.
 
 There is an "audio type" abstraction which refers to different ways to generate audio, e.g. MIDI, waveform synthesis, samples, etc. Adding a new audio type is as simple as providing an implementation for each of the multimethods in this namespace, i.e. `set-up-audio-type!`, `refresh-audio-type!`, `tear-down-audio-type!` and `play-event!`.
 
@@ -194,7 +194,7 @@ The core logic for what goes on behind the curtain when you use the REPL lives i
 
 `alda.now`, when coupled with `alda.lisp`, provides a way to work with Alda scores and play music programmatically within a Clojure application.
 
-`alda.now` provides a `play!` macro, which evaluates the body, finds any new note events that were added to the score, and plays them. 
+`alda.now` provides a `play!` macro, which evaluates the body, finds any new note events that were added to the score, and plays them.
 
 Example usage of `alda.now` in a Clojure application:
 
@@ -206,7 +206,7 @@ Example usage of `alda.now` in a Clojure application:
 (part* "upright-bass")
 
 ; This is optional. If left out, Alda will set up the MIDI synth the first
-; time you tell it to play something. 
+; time you tell it to play something.
 (set-up! :midi)
 
 (play!
@@ -219,10 +219,6 @@ Example usage of `alda.now` in a Clojure application:
 ```
 
 Of note, `alda.repl` uses `alda.now` to play the score the user is creating during the REPL session, so you could think of `alda.repl` as an `alda.now` "sample project."
-
-Another thing to note is that `alda.now` does not load the FluidR3 MIDI soundfont like the CLI version of Alda does by default. In the near future, Alda may be packaged with FluidR3 and `alda.now` could provide a simple helper method to load FluidR3. Currently, FluidR3 is loaded dynamically by the Alda CLI.
-
-If you are interested in using FluidR3 or other MIDI soundfonts with Alda in a Clojure application, you can use [`midi.soundfont`](https://github.com/daveyarwood/midi.soundfont).
 
 ## Testing changes
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ```
                             ________________________________  
-                           /    o   oooo ooo oooo   o o o  /\ 
-                          /    oo  ooo  oo  oooo   o o o  / / 
+                           /    o   oooo ooo oooo   o o o  /\
+                          /    oo  ooo  oo  oooo   o o o  / /
                          /    _________________________  / /  
-                        / // / // /// // /// // /// / / / /   
-                       /___ //////////////////////////_/ /    
-                       \____\________________________\_\/     
+                        / // / // /// // /// // /// / / / /
+                       /___ //////////////////////////_/ /
+                       \____\________________________\_\/
 
                                     ~ alda ~
 ```
@@ -55,7 +55,7 @@ of music: classical, popular, chiptune, electroacoustic, and more!
 
 ### TODO
 
-* [Define and use waveform synthesis instruments](https://github.com/alda-lang/alda/issues/100) 
+* [Define and use waveform synthesis instruments](https://github.com/alda-lang/alda/issues/100)
 * [Import MIDI files](https://github.com/alda-lang/alda/issues/85)
 * [Export to MusicXML](https://github.com/alda-lang/alda/issues/44) for inter-operability with other music software
 * [A more robust REPL](https://github.com/alda-lang/alda/issues/54), tailor-made for editing scores interactively
@@ -81,7 +81,7 @@ Assuming you have [Boot](http://www.boot-clj.com) installed, try this on for siz
     cd alda
     bin/alda play --file test/examples/awobmolg.alda
 
-> NOTE: The first time you run the `play` task, you may need to wait a minute for the FluidR3 MIDI soundfont dependency (~141 MB) to download. Alda uses this soundfont in order to make your JVM's MIDI instruments sound a lot nicer. If you'd prefer to skip this step and use your JVM's default soundfont instead, include the `--stock` flag (i.e. `play --stock --file ...`).
+> NOTE: Default JVM soundfonts usually are of low quality. You can install FluidR3 soundfont by executing `bin/install-fluidr3`. You may need to wait a minute for the FluidR3 MIDI soundfont dependency (~141 MB) to download. Alda uses this soundfont in order to make your JVM's MIDI instruments sound a lot nicer.
 
 You can also execute arbitrary Alda code, like this:
 

--- a/bin/install-fluidr3
+++ b/bin/install-fluidr3
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# this script fetches the latest version of FluidR3 and installs it on your machine
+
+set -e
+
+FLUID_VERSION=0.1.1
+FLUID_NAME=fluid-r3-${FLUID_VERSION}
+FLUID_WORK_FOLDER=fluidr3
+
+echo "Downloading ${FLUID_NAME}"
+curl -O https://repo1.maven.org/maven2/org/bitbucket/daveyarwood/fluid-r3/${FLUID_VERSION}/${FLUID_NAME}.jar
+
+mkdir -p ${FLUID_WORK_FOLDER}
+mv ${FLUID_NAME}.jar ${FLUID_WORK_FOLDER}
+cd ${FLUID_WORK_FOLDER} && unzip -qq ${FLUID_NAME}.jar
+cp fluid-r3.sf2 ~/.gervill/soundbank-emg.sf2
+echo "Installed ${FLUID_NAME}"
+cd .. && rm -rf ${FLUID_WORK_FOLDER}

--- a/build.boot
+++ b/build.boot
@@ -10,7 +10,6 @@
                   [djy                   "0.1.4"]
                   [str-to-argv           "0.1.0"]
                   [overtone              "0.9.1"]
-                  [midi.soundfont        "0.1.0"]
                   [reply                 "0.3.7"]
                   [backtick              "0.3.3"]])
 
@@ -20,7 +19,7 @@
          '[alda.cli]
          '[str-to-argv :refer (split-args)])
 
-; version number is stored in alda.version 
+; version number is stored in alda.version
 (bootlaces! alda.version/-version-)
 
 (task-options!
@@ -55,8 +54,8 @@
 
 (deftask alda
   "Run Alda CLI tasks.
-   
-   Whereas running `bin/alda <cmd> <args>` will use the latest deployed 
+
+   Whereas running `bin/alda <cmd> <args>` will use the latest deployed
    version of Alda, running this task (`boot alda -x '<cmd> <args>'`)
    will use the current (local) version of this repo."
   [x execute ARGS str "The Alda CLI task and args as a single string."]

--- a/src/alda/cli.clj
+++ b/src/alda/cli.clj
@@ -8,15 +8,6 @@
             [alda.sound]
             [alda.util       :as    util]))
 
-(defn fluid-r3!
-  "Fetches FluidR3 dependency and returns the input stream handle."
-  []
-  (eval
-    '(do (merge-env!
-           :dependencies '[[org.bitbucket.daveyarwood/fluid-r3 "0.1.1"]])
-         (require '[midi.soundfont.fluid-r3 :as fluid-r3])
-         fluid-r3/sf2)))
-
 (defclifn ^:alda-task parse
   "Parse some Alda code and print the results to the console."
   [f file FILE str  "The path to a file containing Alda code to parse."
@@ -48,12 +39,10 @@
    c code        CODE str "The string of Alda code to play."
    ; TODO: implement smart buffering and remove the buffer options
    p pre-buffer  MS  int  "The number of milliseconds of lead time for buffering. (default: 0)"
-   P post-buffer MS  int  "The number of milliseconds to keep the synth open after the score ends. (default: 1000)"
-   s stock           bool "Use the default MIDI soundfont of your JVM, instead of FluidR3."]
+   P post-buffer MS  int  "The number of milliseconds to keep the synth open after the score ends. (default: 1000)"]
   (require '[alda.lisp]
            '[instaparse.core])
-  (binding [alda.sound.midi/*midi-soundfont* (when-not stock (fluid-r3!))
-            alda.sound/*play-opts* {:pre-buffer  (or pre-buffer 0)
+  (binding [alda.sound/*play-opts* {:pre-buffer  (or pre-buffer 0)
                                     :post-buffer (or post-buffer 1000)
                                     :one-off?    true}]
     (if-not (or file code)
@@ -67,10 +56,8 @@
 (defclifn ^:alda-task repl
   "Starts an Alda Read-Evaluate-Play-Loop."
   [p pre-buffer  MS int  "The number of milliseconds of lead time for buffering. (default: 0)"
-   P post-buffer MS int  "The number of milliseconds to wait after the score ends. (default: 0)"
-   s stock          bool "Use the default MIDI soundfont of your JVM, instead of FluidR3."]
-  (binding [alda.sound.midi/*midi-soundfont* (when-not stock (fluid-r3!))
-            alda.sound/*play-opts* {:pre-buffer  pre-buffer
+   P post-buffer MS int  "The number of milliseconds to wait after the score ends. (default: 0)"]
+  (binding [alda.sound/*play-opts* {:pre-buffer  pre-buffer
                                     :post-buffer post-buffer
                                     :async?      true}]
     (eval

--- a/src/alda/sound/midi.clj
+++ b/src/alda/sound/midi.clj
@@ -1,6 +1,5 @@
 (ns alda.sound.midi
-  (:require [taoensso.timbre :as log]
-            [midi.soundfont  :refer (load-all-instruments!)])
+  (:require [taoensso.timbre :as log])
   (:import  (javax.sound.midi MidiSystem Synthesizer)))
 
 ; TODO: work around the limitation of 16 MIDI channels?
@@ -11,7 +10,6 @@
 
 (declare ^:dynamic *midi-synth*)
 (declare ^:dynamic *midi-channels*)
-(def ^:dynamic *midi-soundfont* nil)
 
 (defn- next-available
   "Given a set of available MIDI channels, returns the next available one,
@@ -32,12 +30,12 @@
   (let [channels (atom (apply sorted-set (concat (range 0 9) (range 10 16))))]
     (reduce (fn [result id]
               (let [patch   (-> id instruments :config :patch)
-                    ; TODO: pass ":percussion? true" if percussion 
+                    ; TODO: pass ":percussion? true" if percussion
                     channel (if-let [channel (next-available @channels)]
                               (do
                                 (swap! channels disj channel)
                                 channel)
-                              (throw 
+                              (throw
                                 (Exception. "Ran out of MIDI channels! :(")))]
                 (assoc result id {:channel channel
                                   :patch patch})))
@@ -60,10 +58,6 @@
   (log/debug "Loading MIDI synth...")
   (alter-var-root #'*midi-synth*
                   (constantly (doto (MidiSystem/getSynthesizer) .open)))
-  (when *midi-soundfont* 
-    (log/debug "Loading MIDI soundfont...")
-    (load-all-instruments! *midi-synth* *midi-soundfont*)
-    (log/debug "Done loading MIDI soundfont."))
   (log/debug "Done loading MIDI synth."))
 
 (defn close-midi-synth!


### PR DESCRIPTION
Moving to a script that installs FluidR3 for the local user has to be done only once and does not impact `alda` startup. It also allows to start without internet access.

Having such a default soundbank removes the whole process of loading an extra soundbank, removing existing instruments and loading new ones each time `alda` runs.

Finally it is a step in the direction of removing `boot` dependency from `alda`.

(Sorry for the whitespace changes, somehow my editor has been too zealous).