### PR TITLE
Key signatures

### DIFF
--- a/doc/attributes.md
+++ b/doc/attributes.md
@@ -1,0 +1,193 @@
+# Attributes
+
+An **attribute** defines some quality of how an [instrument](scores-and-parts.md) (or multiple instruments) plays its [notes](notes.md).
+
+Under the hood, attributes are implemented as [inline clojure code](inline-clojure-code.md).
+
+## Setting the Value of an Attribute
+
+Just like setting [octaves](notes.md#octave), setting an attribute will take effect for all of an instrument's upcoming notes, until that attribute is changed again. (In fact, `octave` is also a settable attribute.) 
+
+Different attributes take different kinds of values. A lot of the time, the value is a number between 0 and 100, but this is not always the case.
+
+### Examples
+
+```
+(volume 50)
+```
+
+```
+(quant 85)
+```
+
+```
+(octave :up)
+```
+
+```
+(tempo 240)
+```
+
+```
+(key-signature "f+ c+ g+")
+```
+
+See [below](#list-of-attributes) for more information about the different kinds of attributes that are available to you when writing a score.
+
+## Getting the Current Value of an Attribute
+
+To obtain the current value of an attribute for the current instrument(s), prefix the name of the attribute with a dollar sign (`$`). 
+
+You typically will not need to do this when writing a score, but it may be helpful when writing an Alda score via [alda.lisp](alda-lisp.md), or when doing complicated things with inline Clojure code.
+
+As a simple example, this will print the current value of the volume of the piano instance:
+
+```
+piano:
+  (println ($volume))
+  c d e f g
+```
+
+> **Caveat:** When using this syntax in a part with multiple instruments (e.g. `piano/trumpet: (prn ($volume))`), only one of the instruments' values will be returned. Tread with caution!
+
+## Per-Instrument vs. Global
+
+By default, an attribute change event is only applied to the instrument(s) that you're currently working with. For instance, in a score with four instruments:
+
+```
+violin "violin-1": 
+  o4 f2   g4 a   b-2   a
+
+violin "violin-2": 
+  o4 c2   e4 f   f2    f
+
+viola: 
+  o3 a2 > c4 c   d2    c
+
+cello: 
+  o3 f2   c4 f < b-2 > f
+```
+
+Changing an attribute will only affect the instrument(s) whose part you are currently editing:
+
+```
+violin "violin-1": 
+  o4 f2   g4 a   b-2   a
+
+violin "violin-2": 
+  o4 c2   e4 f   f2    f
+
+viola: 
+  o3 a2 > c4 c   d2    c
+
+cello: 
+  (volume 75)
+  o3 f2   c4 f < b-2 > f
+```
+
+To change an attribute **globally** (i.e. for every instrument in the score), add an exclamation mark (`!`) after the name of the attribute:
+
+```
+violin "violin-1": 
+  (tempo! 80)
+  o4 f2   g4 a   b-2   a
+
+violin "violin-2": 
+  o4 c2   e4 f   f2    f
+
+viola: 
+  o3 a2 > c4 c   d2    c
+
+cello: 
+  o3 f2   c4 f < b-2 > f
+```
+
+Attributes can also be set globally at the beginning of a score, before you start writing out any instrument parts. The attributes will still be set for every instrument.
+
+```
+(tempo! 80)
+
+violin "violin-1": 
+  o4 f2   g4 a   b-2   a
+
+violin "violin-2": 
+  o4 c2   e4 f   f2    f
+
+viola: 
+  o3 a2 > c4 c   d2    c
+
+cello: 
+  o3 f2   c4 f < b-2 > f
+```
+
+## List of Attributes
+
+### `duration`
+
+* **Abbreviations:** (none)
+
+* **Description:** The length that a note will have, if not specified. For example, `c4` is explicitly a quarter note; `c` will have a note-length equal to the value of the instrument's `duration` attribute. (Note that this attribute is more of an implementation detail, as it is called implicitly whenever you specify a note-length for a note. You will probably never need to use this attribute directly.)
+
+* **Value:** a number of beats (e.g. 2.5, which represents a dotted half note).
+
+* **Initial Value:** 1 (i.e. a quarter note)
+
+### `key-signature`
+
+* **Abbreviations:** `key-sig`
+
+* **Description:** [a set of sharp or flat symbols](https://en.wikipedia.org/wiki/Key_signature) to be applied to certain notes by default when the note doesn't include accidentals. For example, if the key signature contains G-sharp, then a note `g` will become G-sharp by default, unless an accidental is placed after the note, i.e. `g-` (G-flat) or `g` (G natural).
+
+* **Value:** either a map of letters (as keywords) to lists of accidentals for that letter, e.g. `{:f [:sharp] :c [:sharp] :g [:sharp]}`, or a string of the form `"f+ c+ g+"`
+
+* **Initial Value:** `{}` (an empty map, signifying no flats/sharps will be applied for any letter)
+
+### `octave`
+
+* **Abbreviations:** (none)
+
+* **Description:** The octave of a note. (Note that Alda also has built-in syntax for setting specific octaves, e.g. `o5`, and moving up `>` or down `<` octaves.)
+
+* **Value:** either a number representing an octave in [scientific pitch notation](https://en.wikipedia.org/wiki/Scientific_pitch_notation), or the keyword `:up` or `:down` to move up or down by one from the current octave.
+
+* **Initial Value:** 4
+
+### `quantization`
+
+* **Abbreviations:** `quant`, `quantize`
+
+* **Description:** The percentage of a note's full duration that is heard. Setting lower `quantization` values translates into putting more space between notes, making them sound more *staccato*, whereas setting higher values translates into putting *less* space between notes, making them sound more *legato*.
+
+* **Value:** a number between 0 and 100
+
+* **Initial Value:** 90
+
+### `tempo`
+
+* **Abbreviations:** (none)
+
+* **Description:** How fast or slow notes are played. This value is used in combination with the length of a note to determine how long to play it in milliseconds.
+
+* **Value:** a number representing a [tempo](https://en.wikipedia.org/wiki/Tempo) in beats per minute (BPM)
+
+* **Initial Value:** 120
+
+### `track-volume`
+
+* **Abbreviations:** `track-vol`
+
+* **Description:** The overall volume of an instrument. For MIDI instruments, this corresponds to track volume, as opposed to velocity. Typically, you would set `track-volume` once (if at all) at the beginning of the score, and then use `volume` for finer-grained control over volume between notes. (When in doubt, just use `volume`!)
+
+* **Value:** a number between 0 and 100
+
+* **Initial Value:** 78.7 (this number comes from 100/127, which is the default track volume for MIDI, at least on the JVM)
+
+### `volume`
+
+* **Abbreviations:** `vol`
+
+* **Description:** How loud or soft a note is. For MIDI instruments, this corresponds to the *velocity* of each note, which has to do with not only how loud the note is, but also how *strongly* the note is played. The details of this vary from instrument to instrument; often, it has an effect on the sharpness of the attack at the beginning of the note.
+
+* **Value:** a number between 0 and 100
+
+* **Initial Value:** 100

--- a/doc/attributes.md
+++ b/doc/attributes.md
@@ -138,7 +138,10 @@ cello:
 
 * **Description:** [a set of sharp or flat symbols](https://en.wikipedia.org/wiki/Key_signature) to be applied to certain notes by default when the note doesn't include accidentals. For example, if the key signature contains G-sharp, then a note `g` will become G-sharp by default, unless an accidental is placed after the note, i.e. `g-` (G-flat) or `g` (G natural).
 
-* **Value:** either a map of letters (as keywords) to lists of accidentals for that letter, e.g. `{:f [:sharp] :c [:sharp] :g [:sharp]}`, or a string of the form `"f+ c+ g+"`
+* **Value:** either:
+  * a map of letters (as keywords) to lists of accidentals for that letter, e.g. `{:f [:sharp] :c [:sharp] :g [:sharp]}`,
+  * a string like `"f+ c+ g+"`, or
+  * a vector like `[:a :major]` or `[:e :flat :minor]`
 
 * **Initial Value:** `{}` (an empty map, signifying no flats/sharps will be applied for any letter)
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -15,7 +15,14 @@ If you've come here for any other reason, uh, go away, I guess.
 
 * Learn about the [etymology](etymology.md) behind the name Alda.
 
-* The article on [scores and parts](scores-and-parts.md) provides some good general information on what an Alda score is. After that, you can start learning about [notes](notes.md), [rests](rests.md), [chords](chords.md), [voices](voices.md), [markers](markers.md), [offset](offset.md)...
+* The article on [scores and parts](scores-and-parts.md) provides some good general information on what an Alda score is. After that, you may be interested in learning about... 
+  * [notes](notes.md)
+  * [rests](rests.md)
+  * [chords](chords.md)
+  * [voices](voices.md)
+  * [markers](markers.md)
+  * [offset](offset.md)
+  * [attributes](attributes.md)
 
 ## How to Use the Docs
 

--- a/doc/inline-clojure-code.md
+++ b/doc/inline-clojure-code.md
@@ -1,0 +1,5 @@
+# Inline Clojure Code
+
+Alda allows score-writers to program in [Clojure](http://www.clojure.org) by writing inline Clojure expressions alongside Alda code.
+
+*This article is a stub. Improve me!*

--- a/doc/notes.md
+++ b/doc/notes.md
@@ -36,11 +36,21 @@ Alda keeps track of both the current octave and the current default note duratio
 
 A note in Alda is expressed as a letter from a-g, any number of accidentals (optional), and a note duration (also optional).
 
-Flats and sharps will decrease/increase the pitch by one half step, e.g. C + 1/2 step = C#. Flats and sharps are expressed in Alda as - and +, and you can have multiple sharps or multiple flats, or even combine them, if you'd like. e.g. `c++` = C double-sharp = D. 
+Flats and sharps will decrease/increase the pitch by one half step, e.g. C + 1/2 step = C#. Flats and sharps are expressed in Alda as `-` and `+`, and you can have multiple sharps or multiple flats, or even combine them, if you'd like. e.g. `c++` = C double-sharp = D. 
+
+As an alternative to placing flats and sharps on every note that needs them, you may prefer to set the [key signature](attributes.md#key-signature), which will add the necessary sharps/flats to any note that needs them in order to match the key. See below for an example of using a key signature.
+
+To overwrite the flat/sharp specified by a key signature, you can include an accidental, i.e. `-` or `+` to make the note flat or sharp. You can also override the key signature and force a note to be natural with `=`, i.e. `c=` is a C natural regardless of what key you are in.
 
 ## Example 
 
 The following is a 1-octave B major scale, ascending and descending, starting in octave 4:
 
     o4 b4 > c+8 d+ e f+ g+ a+ b4
-    a+ g+ f+ e d+ c+ < b2.
+    a+8 g+ f+ e d+ c+ < b2.
+
+Here is the same example, using a key signature in order to avoid having to include all of the sharps:
+
+    (key-signature "f+ c+ g+ d+ a+")
+    o4 b4 > c8 d e f g a b4
+    a8 g f e d c < b2.

--- a/grammar/alda.bnf
+++ b/grammar/alda.bnf
@@ -26,7 +26,7 @@ chord                   = (note | rest) subchord+
 note                    = pitch duration? <ows> slur?
 rest                    = <"r"> duration? <ows>
 
-pitch                   = !name #"[a-g][+-]*"
+pitch                   = !name #"[a-g][+-=]*"
 duration                = note-length <ows> barline? <ows> subduration* slur?
 <subduration>           = tie <ows> barline? <ows> note-length <ows> barline? <ows>
 note-length             = number dots?

--- a/grammar/alda.bnf
+++ b/grammar/alda.bnf
@@ -26,7 +26,11 @@ chord                   = (note | rest) subchord+
 note                    = pitch duration? <ows> slur?
 rest                    = <"r"> duration? <ows>
 
-pitch                   = !name #"[a-g][+-=]*"
+pitch                   = !name #"[a-g]" accidental*
+<accidental>            = flat | sharp | natural
+flat                    = "-"
+sharp                   = "+"
+natural                 = "="
 duration                = note-length <ows> barline? <ows> subduration* slur?
 <subduration>           = tie <ows> barline? <ows> note-length <ows> barline? <ows>
 note-length             = number dots?

--- a/src/alda/lisp/attributes.clj
+++ b/src/alda/lisp/attributes.clj
@@ -1,4 +1,5 @@
-(ns alda.lisp.attributes)
+(ns alda.lisp.attributes
+  (:require [alda.lisp.model.key]))
 (in-ns 'alda.lisp)
 
 (log/debug "Loading alda.lisp.attributes...")
@@ -77,13 +78,21 @@
    converted to a letter->accidentals map."
   [key-sig]
   (constantly
-    (if (map? key-sig)
+    (cond
+      (map? key-sig)
       key-sig
+
+      (string? key-sig)
       (into {}
         (map (fn [[_ _ letter accidentals]]
-               [(keyword letter) (map {\- :flat \+ :sharp \= :natural}
-                                      accidentals)])
-             (re-seq #"(([a-g])([+-=]*))" key-sig))))))
+               [(keyword letter) 
+                (map {\- :flat \+ :sharp \= :natural} accidentals)])
+             (re-seq #"(([a-g])([+-=]*))" key-sig)))
+
+      (sequential? key-sig)
+      (let [[scale-type & more]    (reverse key-sig)
+            [letter & accidentals] (reverse more)]
+        (get-key-signature scale-type letter accidentals)))))
 
 (defattribute key-signature
    "The key in which the current instrument is playing."

--- a/src/alda/lisp/attributes.clj
+++ b/src/alda/lisp/attributes.clj
@@ -65,3 +65,15 @@
   :aliases [:pan]
   :initial-val 0.5
   :transform percentage)
+
+(defn- parse-key-signature
+  "Transforms a key signature ((:c :sharp :sharp) (:d :flat)) into a letter
+   to accidentals map {:c (:sharp :sharp), :d (:flat)}."
+  [pitches]
+  (into {} (map (fn [pitch] {(first pitch) (rest pitch)}) pitches)))
+
+(defattribute key-signature
+   "The key in which the current instrument is playing."
+   :aliases [:key]
+   :initial-val {}
+   :transform (fn [val] (constantly (parse-key-signature (rest val)))))

--- a/src/alda/lisp/events/note.clj
+++ b/src/alda/lisp/events/note.clj
@@ -30,8 +30,11 @@
                             :instrument   instrument
                             :volume       ($volume instrument)
                             :track-volume ($track-volume instrument)
-                            :midi-note    (pitch-fn ($octave instrument) ($key-signature instrument) :midi true)
-                            :pitch        (pitch-fn ($octave instrument) ($key-signature instrument))
+                            :midi-note    (pitch-fn ($octave instrument) 
+                                                    ($key-signature instrument) 
+                                                    :midi true)
+                            :pitch        (pitch-fn ($octave instrument) 
+                                                    ($key-signature instrument))
                             :duration     (* note-duration quant)})]
       (add-event instrument event)
       (set-last-offset instrument ($current-offset instrument))

--- a/src/alda/lisp/events/note.clj
+++ b/src/alda/lisp/events/note.clj
@@ -30,8 +30,8 @@
                             :instrument   instrument
                             :volume       ($volume instrument)
                             :track-volume ($track-volume instrument)
-                            :midi-note    (pitch-fn ($octave instrument) :midi true)
-                            :pitch        (pitch-fn ($octave instrument))
+                            :midi-note    (pitch-fn ($octave instrument) ($key-signature instrument) :midi true)
+                            :pitch        (pitch-fn ($octave instrument) ($key-signature instrument))
                             :duration     (* note-duration quant)})]
       (add-event instrument event)
       (set-last-offset instrument ($current-offset instrument))

--- a/src/alda/lisp/model/key.clj
+++ b/src/alda/lisp/model/key.clj
@@ -1,0 +1,76 @@
+(ns alda.lisp.model.key)
+(in-ns 'alda.lisp)
+
+(defn- remove-first [x coll]
+  (concat (take-while (partial not= x) coll)
+          (rest (drop-while (partial not= x) coll))))
+
+(defn- shift-key
+  "Raises or lowers a key signature by one semitone, depending on the values of
+   `this` and `that`. (Implementation for sharpen-key and flatten-key.)"
+  [this that]
+  (fn [key-sig]
+    (apply conj {}
+              (map (fn [letter]
+                     (let [accidentals (key-sig letter)]
+                       (cond
+                         (nil? accidentals)
+                         [letter [this]]
+
+                         (= accidentals [that])
+                         nil
+
+                         (contains? (set accidentals) that)
+                         [letter (remove-first that accidentals)]
+                         
+                         :else
+                         [letter (conj accidentals this)])))
+                   (map (comp keyword str) "abcdefg")))))
+
+(def ^:private sharpen-key
+  "Raises a key signature by one semitone.
+   
+   All notes in the key signature that were flat become natural, notes that
+   were natural become sharp, notes that were sharp become double-sharp, etc.
+   
+   e.g. Db major -> D major
+   {:b [:flat] :e [:flat] :a [:flat] :d [:flat] :g [:flat]}
+   becomes
+   {:f [:sharp] :c [:sharp]}"
+  (shift-key :sharp :flat))
+
+(def ^:private flatten-key
+  "Lowers a key signature by one semitone.
+   
+   All notes in the key signature that were sharp become natural, notes that
+   were natural become flat, notes that were flat become double-flat, etc.
+   
+   e.g. F# major to F major
+   {:f [:sharp] :c [:sharp] :g [:sharp] :d [:sharp] :a [:sharp] :e [:sharp]}
+   becomes
+   {:b [:flat]}"
+  (shift-key :flat :sharp))
+
+(defn partial-circle-of-fifths
+  [scale-type]
+  (zipmap (map (comp keyword str) "fcgdaeb")
+          (case scale-type
+            :major (range -1 6)
+            :minor (range -4 3))))
+
+(defn get-key-signature
+  ([scale-type letter]
+    (into {}
+      (let [n          (get (partial-circle-of-fifths scale-type) letter)
+            letters    (take (Math/abs n) 
+                             (map (comp keyword str) 
+                                  (if (pos? n) "fcgdaeb" "beadgcf")))
+            accidental (if (pos? n) :sharp :flat)]
+        (map (fn [ltr] [ltr [accidental]]) letters))))
+  ([scale-type letter accidentals]
+    (reduce (fn [key-sig accidental]
+              (case accidental
+                :flat (flatten-key key-sig)
+                :sharp (sharpen-key key-sig)))
+            (get-key-signature scale-type letter)
+            accidentals)))

--- a/src/alda/lisp/model/pitch.clj
+++ b/src/alda/lisp/model/pitch.clj
@@ -17,38 +17,29 @@
   [note]
   (* 440.0 (Math/pow 2.0 (/ (- note 69.0) 12.0))))
 
-(defn- check-key
+(defn- apply-key
   "Modifies the accidentals on notes to fit the key signature.
-   If there are no accidentals and this letter is in the signature, 
-   return the letter's signature accidentals, otherwise return 
-   existing accidentals"
+
+   If there are no accidentals and this letter is in the signature, return the
+   letter's signature accidentals, otherwise return existing accidentals."
   [signature letter accidentals]
    (if (empty? accidentals)
-       (get signature letter nil) 
-       (identity accidentals)))
+     (get signature letter)
+     accidentals))
 
 (defn pitch
   "Returns a fn that will calculate the frequency in Hz, within the context
-   of the octave that an instrument is in."
-  [parsed-pitch]
-  (let [letter (first parsed-pitch) accidentals (rest parsed-pitch)]
-  (fn [octave key-signature & {:keys [midi]}]
+   of an instrument's octave and key signature."
+  [letter & accidentals]
+  (fn [octave key-sig & {:keys [midi]}]
     (let [midi-note (reduce (fn [number accidental]
-                              (log/debug (format "number %s accidental %s" number accidental))
                               (case accidental
                                 :flat    (dec number)
                                 :sharp   (inc number)
                                 :natural (identity number)))
                             (midi-note letter octave)
-                            (check-key key-signature letter accidentals) )]
+                            (apply-key key-sig letter accidentals))]
       (if midi
         midi-note
-        (midi->hz midi-note))))))
+        (midi->hz midi-note)))))
 
-(defn parse-pitch 
-  "Converts the tokenized representation of a pitch into a keyword sequence.
-   For example, ('c' '+' '+') will become (:c :sharp :sharp)"
-  [letter & accidentals]
-  (list* (keyword (str letter))
-        (map {\+ :sharp, \= :natural, \- :flat} accidentals))
-)

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -85,16 +85,12 @@
           :slur              (constantly :slur)
           :flat              (constantly :flat)
           :sharp             (constantly :sharp)
+          :natural           (constantly :natural)
           :dots              #(hash-map :dots (count %))
           :note-length       #(list* 'alda.lisp/note-length %&)
           :duration          #(list* 'alda.lisp/duration %&)
-          :pitch             (fn [s]
-                               (list* 'alda.lisp/pitch
-                                      (keyword (str (first s)))
-                                      (map #(case %
-                                              \- :flat
-                                              \+ :sharp)
-                                           (rest s))))
+          :pitch             #(list* 'alda.lisp/pitch %&)
+          :pitch-notation    #(list* 'alda.lisp/parse-pitch %)
           :note              #(list* 'alda.lisp/note %&)
           :rest              #(list* 'alda.lisp/pause %&)
           :chord             #(list* 'alda.lisp/chord %&)

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -89,8 +89,8 @@
           :dots              #(hash-map :dots (count %))
           :note-length       #(list* 'alda.lisp/note-length %&)
           :duration          #(list* 'alda.lisp/duration %&)
-          :pitch             #(list* 'alda.lisp/pitch %&)
-          :pitch-notation    #(list* 'alda.lisp/parse-pitch %)
+          :pitch             (fn [letter & accidentals] 
+                               (list* 'alda.lisp/pitch (keyword letter) accidentals))
           :note              #(list* 'alda.lisp/note %&)
           :rest              #(list* 'alda.lisp/pause %&)
           :chord             #(list* 'alda.lisp/chord %&)

--- a/test/alda/lisp/global_attributes_test.clj
+++ b/test/alda/lisp/global_attributes_test.clj
@@ -43,5 +43,5 @@
         (is (= ($tempo) 120))
         (pause)
         (is (= ($tempo) 120)))))) ; tempo should still be 120,
-; despite having passed 2000 ms
+                                  ; despite having passed 2000 ms
 (alter-var-root #'*global-attributes* (constantly {}))

--- a/test/alda/lisp/notes_test.clj
+++ b/test/alda/lisp/notes_test.clj
@@ -12,7 +12,7 @@
 (deftest note-tests
   (testing "a note event:"
     (let [start ($current-offset)
-          c ((pitch :c) ($octave))
+          c ((pitch :c) ($octave) ($key-signature))
           {:keys [duration offset pitch]}
           (first (note (pitch :c) (duration (note-length 4) :slur)))]
       (testing "should be placed at the current offset"

--- a/test/alda/lisp/pitch_test.clj
+++ b/test/alda/lisp/pitch_test.clj
@@ -36,7 +36,11 @@
     (key-signature {:b [:flat] :e [:flat]})
     (is (= {:b [:flat] :e [:flat]} ($key-signature)))
     (key-sig "f+ c+ g+")
-    (is (= {:f [:sharp] :c [:sharp] :g [:sharp]} ($key-signature))))
+    (is (= {:f [:sharp] :c [:sharp] :g [:sharp]} ($key-signature)))
+    (key-sig [:a :flat :major])
+    (is (= {:b [:flat] :e [:flat] :a [:flat] :d [:flat]} ($key-signature)))
+    (key-sig [:e :minor])
+    (is (= {:f [:sharp]} ($key-signature))))
   (testing "the pitch of a note is affected by the key signature"
     (is (= ((pitch :b) 4 {:b [:flat]})
            ((pitch :b :flat) 4 {})))

--- a/test/alda/lisp/pitch_test.clj
+++ b/test/alda/lisp/pitch_test.clj
@@ -10,15 +10,38 @@
 
 (deftest pitch-tests
   (testing "pitch converts a note in a given octave to frequency in Hz"
-    (is (== 440 ((pitch :a) 4)))
-    (is (== 880 ((pitch :a) 5)))
-    (is (< 261 ((pitch :c) 4) 262)))
+    (is (== 440 ((pitch :a) 4 {})))
+    (is (== 880 ((pitch :a) 5 {})))
+    (is (< 261 ((pitch :c) 4 {}) 262)))
   (testing "flats and sharps"
-    (is (>  ((pitch :c :sharp) 4) ((pitch :c) 4)))
-    (is (>  ((pitch :c) 5) ((pitch :c :sharp) 4)))
-    (is (<  ((pitch :b :flat) 4)  ((pitch :b) 4)))
-    (is (== ((pitch :c :sharp) 4) ((pitch :d :flat) 4)))
-    (is (== ((pitch :c :sharp :sharp) 4) ((pitch :d) 4)))
-    (is (== ((pitch :f :flat) 4) ((pitch :e) 4)))
-    (is (== ((pitch :a :flat :flat) 4) ((pitch :g) 4)))
-    (is (== ((pitch :c :sharp :flat :flat :sharp) 4) ((pitch :c) 4)))))
+    (is (> ((pitch :c :sharp) 4 {}) 
+           ((pitch :c) 4 {})))
+    (is (> ((pitch :c) 5 {}) 
+           ((pitch :c :sharp) 4 {})))
+    (is (< ((pitch :b :flat) 4 {})  
+           ((pitch :b) 4 {})))
+    (is (== ((pitch :c :sharp) 4 {}) 
+            ((pitch :d :flat) 4 {})))
+    (is (== ((pitch :c :sharp :sharp) 4 {}) 
+            ((pitch :d) 4 {})))
+    (is (== ((pitch :f :flat) 4 {}) 
+            ((pitch :e) 4 {})))
+    (is (== ((pitch :a :flat :flat) 4 {}) 
+            ((pitch :g) 4 {})))
+    (is (== ((pitch :c :sharp :flat :flat :sharp) 4 {}) 
+            ((pitch :c) 4 {})))))
+
+(deftest key-tests
+  (testing "you can set and get a key signature"
+    (key-signature {:b [:flat] :e [:flat]})
+    (is (= {:b [:flat] :e [:flat]} ($key-signature)))
+    (key-sig "f+ c+ g+")
+    (is (= {:f [:sharp] :c [:sharp] :g [:sharp]} ($key-signature))))
+  (testing "the pitch of a note is affected by the key signature"
+    (is (= ((pitch :b) 4 {:b [:flat]})
+           ((pitch :b :flat) 4 {})))
+    (key-signature "f+")
+    (let [f-sharp-4 ((pitch :f) 4 ($key-signature))]
+      (is (= f-sharp-4 ((pitch :f :sharp) 4 {}))))
+    (is (= ((pitch :b :natural) 4 {:b [:flat]})
+           ((pitch :b) 4 {})))))

--- a/test/examples/key_signature.alda
+++ b/test/examples/key_signature.alda
@@ -1,10 +1,11 @@
 vibraphone:
+  (quant 200)
   (key-signature "f+ c+ g+")
   a8 b > c d e f g a <
   a b > c= d e f= g= a <
 
-  (key-signature "f+")
-  g a b > c d e f= g <
+  (key-signature [:g :minor])
+  g a b > c+ d e f+ g <
 
   (key-signature {:e [:flat] :b [:flat]})
   g1~1/b/d

--- a/test/examples/key_signature.alda
+++ b/test/examples/key_signature.alda
@@ -1,0 +1,10 @@
+vibraphone:
+  (key-signature "f+ c+ g+")
+  a8 b > c d e f g a <
+  a b > c= d e f= g= a <
+
+  (key-signature "f+")
+  g a b > c d e f= g <
+
+  (key-signature {:e [:flat] :b [:flat]})
+  g1~1/b/d


### PR DESCRIPTION
Closes #36.

This is an iteration on PR #89 started by @FragLegs. After just a few tweaks, it's working great! Not having to worry about the parsing step due to #94 is a big win.

TODO:
* [X] add docs
* [x] allow specifying the key signature as a scale, in the form of a vector like `[:a :major]` (should be easy™)
