### PR TITLE
Code block literals and the "alda-code" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ of music: classical, popular, chiptune, electroacoustic, and more!
 * Represent scores as text files and play them back with the `alda` command-line tool
 * [Interactive REPL](doc/alda-repl.md) lets you type Alda code and hear the results in real time
 * [Underlying Clojure DSL](doc/alda-lisp.md) allows you to [use Alda directly in your Clojure project](doc/alda-now.md).
-* Inline Clojure code allows you to [hack the Gibson][hackers] and write scores programmatically
+* [Inline Clojure code](doc/inline-clojure-code.md) allows you to [hack the Gibson][hackers] and write scores programmatically
 * Create MIDI music using any of the instruments in the [General MIDI Sound Set][gm-sound-set]
 
 [hackers]: https://www.youtube.com/watch?v=vYNnPx8fZBs

--- a/build.boot
+++ b/build.boot
@@ -37,6 +37,7 @@
   test {:namespaces '#{
                        alda.parser.barlines-test
                        alda.parser.clj-exprs-test
+                       alda.parser.code-blocks-test
                        alda.parser.comments-test
                        alda.parser.duration-test
                        alda.parser.events-test

--- a/doc/inline-clojure-code.md
+++ b/doc/inline-clojure-code.md
@@ -2,4 +2,37 @@
 
 Alda allows score-writers to program in [Clojure](http://www.clojure.org) by writing inline Clojure expressions alongside Alda code.
 
-*This article is a stub. Improve me!*
+From the perspective of Alda's parser, anything between parentheses is considered a Clojure expression. You can write Clojure expressions anywhere within in Alda score, alongside Alda syntax.
+
+Clojure expressions are evaluated in the context of the `alda.lisp` namespace, which gives you first-class access to the [alda.lisp](alda-lisp.md) DSL. For example, out of the box you can do things like:
+
+```clojure
+(note (pitch :c))
+
+(do (volume 50) (octave 6))
+
+(chord (note (pitch :c))
+       (note (pitch :e))
+       (note (pitch :g)))
+```
+
+## Evaluating strings of Alda code
+
+The `alda-code` function provides a convenient way to parse and evaluate a string of Alda code, in the context of inline Clojure code. This gives you the power to construct strings of Alda code using Clojure, and then splice that Alda code into your score.
+
+Here is an example where we repeat a 3-note phrase 7 times by building the string `"e f g e f g e f g e f g e f g e f g e f g "` and evaluating it:
+
+```
+cello:
+  o3
+  (alda-code (apply str (repeat 7 "e8 f g ")))
+```
+
+Here is another example, where we play 5 random notes out of the C major scale:
+
+```
+bassoon:
+  o3
+  (alda-code (apply str (repeatedly 5 #(str (rand-nth "abcdefg") \space))))
+```
+

--- a/grammar/alda.bnf
+++ b/grammar/alda.bnf
@@ -12,9 +12,10 @@ nickname                = <"\""> acceptable-name <"\"">
 
     (* notes, chords & other events *)
 
-<music-data>            = (voices | event)*
+<music-data>            = <ows> (voices | event)*
 <event>                 = chord | note | rest | octave-change |
-                          clj-expr | marker | at-marker | barline
+                          clj-expr | marker | at-marker | barline |
+                          code-block
 voices                  = voice+ (<voice-zero> | <#"\z"> | &part)
 voice                   = voice-number event*
 voice-number            = <"V"> #"[1-9]\d*" <":"> <ows>
@@ -63,6 +64,11 @@ clj-string              = <"\""> inside-clj-string* <"\"">
 clj-expr                = <"("> inside-clj-expr* <")"> <ows>
 <inside-clj-expr>       = !( "(" | ")" | "\"" | "\\" )
                           #".|\n|\r" | clj-string | clj-character | clj-expr
+
+    (* alda code blocks *)
+
+code-block              = <"["> inside-code-block* <"]"> <ows>
+<inside-code-block>     = !( "[" | "]") #".|\n\r" | code-block
 
     (* comments & whitespace *)
 

--- a/grammar/alda.bnf
+++ b/grammar/alda.bnf
@@ -67,8 +67,9 @@ clj-expr                = <"("> inside-clj-expr* <")"> <ows>
 
     (* alda code blocks *)
 
-code-block              = <"["> inside-code-block* <"]"> <ows>
-<inside-code-block>     = !( "[" | "]") #".|\n\r" | code-block
+code-block              = code-block-no-ws <ows>
+code-block-no-ws        = <"["> inside-code-block* <"]">
+<inside-code-block>     = !( "[" | "]") #".|\n|\r" | code-block-no-ws
 
     (* comments & whitespace *)
 

--- a/src/alda/lisp.clj
+++ b/src/alda/lisp.clj
@@ -6,7 +6,8 @@
             [alda.lisp.attributes]
             [alda.lisp.events]
             [alda.lisp.instruments]
-            [alda.lisp.score]))
+            [alda.lisp.score]
+            [alda.lisp.code]))
 
 ; example: creating a score interactively at the repl
 

--- a/src/alda/lisp/code.clj
+++ b/src/alda/lisp/code.clj
@@ -1,0 +1,22 @@
+(ns alda.lisp.code)
+(in-ns 'alda.lisp)
+
+(require '[alda.parser-util :refer (parse-with-context)])
+
+(defn code-block
+  "Represents a literal string of Alda code in alda.lisp.
+   
+   When evaluated, simply returns the string of code."
+  [code]
+  code)
+
+(defn alda-code
+  "Attempts to parse a string of text within the context of the current score,
+   then evaluates the result."
+  [code]
+  (let [[context parse-result] (parse-with-context code)]
+    (eval (case context
+            :music-data    (cons 'do parse-result)
+            :score         (cons 'do (rest parse-result))
+            :parse-failure (log/error (pr-str parse-result))
+            parse-result))))

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -38,14 +38,14 @@
          {:clj-character     #(str \\ %)
           :clj-string        #(str \" (apply str %&) \")
           :clj-expr          #(read-clj-expr %&)
-          :code-block        #(list 
-                                'alda.lisp/code-block
-                                (apply str 
-                                       (map (fn [x]
-                                              (if (list? x)
-                                                (str \[ (second x) \])
-                                                x)) 
-                                            %&)))
+          :code-block        #(list 'alda.lisp/code-block (second %))
+          :code-block-no-ws  #(list :code-block-no-ws
+                                    (apply str 
+                                           (map (fn [x]
+                                                  (if (list? x)
+                                                    (str \[ (second x) \])
+                                                    x))
+                                                %&)))
           :name              #(hash-map :name %)
           :nickname          #(hash-map :nickname %)
           :number            identity

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -38,6 +38,14 @@
          {:clj-character     #(str \\ %)
           :clj-string        #(str \" (apply str %&) \")
           :clj-expr          #(read-clj-expr %&)
+          :code-block        #(list 
+                                'alda.lisp/code-block
+                                (apply str 
+                                       (map (fn [x]
+                                              (if (list? x)
+                                                (str \[ (second x) \])
+                                                x)) 
+                                            %&)))
           :name              #(hash-map :name %)
           :nickname          #(hash-map :nickname %)
           :number            identity
@@ -73,3 +81,4 @@
                                    {:names names})))
           :part              #(list* 'alda.lisp/part %&)
           :score             #(list* 'alda.lisp/score %&)})))
+

--- a/src/alda/parser_util.clj
+++ b/src/alda/parser_util.clj
@@ -1,0 +1,36 @@
+(ns alda.parser-util
+  (:require [alda.parser     :refer (parse-input)]
+            [instaparse.core :as    insta]
+            [clojure.java.io :as    io]))
+
+(defn parse-with-start-rule
+  "Parse a string of Alda code starting from a particular level of the tree.
+   (e.g. starting from :part, will parse the string as a part, not a whole score)
+
+   With each line of Alda code entered into the REPL, we determine the context of
+   evaluation (Are we starting a new part? Are we appending events to an existing
+   part? Are we continuing a previous voice? Starting a new voice?) and parse the
+   code accordingly."
+  [start code]
+  (with-redefs [alda.parser/alda-parser
+                #((insta/parser (io/resource "alda.bnf")) % :start start)]
+    (parse-input code)))
+
+(defn parse-with-context
+  "Determine the appropriate context to parse a line of code from the Alda
+   REPL, then parse it within that context.
+   
+   Returns both the context (the name of a parse tree node) and the resulting
+   parse tree.
+   
+   If parsing fails, returns `:parse-failure` and the Instaparse failure object."
+  [alda-code]
+  (letfn [(try-ctxs [[ctx & ctxs]]
+            (let [parsed (parse-with-start-rule ctx alda-code)]
+              (if (insta/failure? parsed)
+                (if ctxs
+                  (try-ctxs ctxs)
+                  [:parse-failure parsed])
+                [ctx parsed])))]
+    (try-ctxs [:music-data :part :score])))
+

--- a/test/alda/lisp/attributes_test.clj
+++ b/test/alda/lisp/attributes_test.clj
@@ -52,7 +52,7 @@
 
 (deftest note-length-tests
   (testing "note-length"
-    (set-attribute :note-length (duration (note-length 2 {:dots 2})))
+    (set-duration (note-length 2 {:dots 2}))
     (is (== ($duration) 3.5))
-    (set-attribute :note-length (duration (note-length 1) (note-length 1)))
+    (set-duration (+ (note-length 1) (note-length 1)))
     (is (== ($duration) 8))))

--- a/test/alda/parser/barlines_test.clj
+++ b/test/alda/parser/barlines_test.clj
@@ -39,17 +39,17 @@
       [:calls [:name "marimba"]]
       [:note [:pitch "c"]
              [:duration
-               [:note-length [:number "1"]]
+               [:note-length [:positive-number "1"]]
                [:barline]
-               [:note-length [:number "1"]]
+               [:note-length [:positive-number "1"]]
                [:barline]
-               [:note-length [:number "1"]]
+               [:note-length [:positive-number "1"]]
                [:barline]
-               [:note-length [:number "1"]]
+               [:note-length [:positive-number "1"]]
                [:barline]
-               [:note-length [:number "1"]]
+               [:note-length [:positive-number "1"]]
                [:barline]
-               [:note-length [:number "2"] [:dots "."]]]]]])
+               [:note-length [:positive-number "2"] [:dots "."]]]]]])
 
 (def alda-lisp-code-2
   '(alda.lisp/score

--- a/test/alda/parser/clj_exprs_test.clj
+++ b/test/alda/parser/clj_exprs_test.clj
@@ -4,83 +4,83 @@
 
 (deftest attribute-tests
   (testing "volume change"
-    (is (= (test-parse :clj-expr "(volume 50)") '(alda.lisp/volume 50))))
+    (is (= (test-parse :clj-expr "(volume 50)") '(volume 50))))
   (testing "tempo change"
-    (is (= (test-parse :clj-expr "(tempo 100)") '(alda.lisp/tempo 100))))
+    (is (= (test-parse :clj-expr "(tempo 100)") '(tempo 100))))
   (testing "quantization change"
-    (is (= (test-parse :clj-expr "(quant 75)") '(alda.lisp/quant 75))))
+    (is (= (test-parse :clj-expr "(quant 75)") '(quant 75))))
   (testing "panning change"
-    (is (= (test-parse :clj-expr "(panning 0)") '(alda.lisp/panning 0)))))
+    (is (= (test-parse :clj-expr "(panning 0)") '(panning 0)))))
 
 (deftest multiple-attribute-change-tests
   (testing "attribute changes"
     (is (= (test-parse :clj-expr "(do (vol 50) (tempo 100))")
-           '(do (alda.lisp/vol 50) (alda.lisp/tempo 100))))
+           '(do (vol 50) (tempo 100))))
     (is (= (test-parse :clj-expr "(do (quant! 50) (tempo 90))")
-           '(do (alda.lisp/quant! 50) (alda.lisp/tempo 90)))))
+           '(do (quant! 50) (tempo 90)))))
   (testing "global attribute changes"
     (is (= (test-parse :clj-expr "(tempo! 126)")
-           '(alda.lisp/tempo! 126)))
+           '(tempo! 126)))
     (is (= (test-parse :clj-expr "(do (tempo! 130) (quant! 80))")
-           '(do (alda.lisp/tempo! 130) (alda.lisp/quant! 80))))))
+           '(do (tempo! 130) (quant! 80))))))
 
 (deftest comma-and-semicolon-tests
   (testing "commas/semicolons can exist in strings"
     (is (= (test-parse :clj-expr "(println \"hi; hi, hi\")")
-           '(clojure.core/println "hi; hi, hi"))))
+           '(println "hi; hi, hi"))))
   (testing "commas inside [brackets] and {braces} won't break things"
     (is (= (test-parse :clj-expr "(prn [1,2,3])")
-           '(clojure.core/prn [1 2 3])))
+           '(prn [1 2 3])))
     (is (= (test-parse :clj-expr "(prn {:a 1, :b 2})")
-           '(clojure.core/prn {:a 1 :b 2}))))
+           '(prn {:a 1 :b 2}))))
   (testing "comma/semicolon character literals are OK too"
     (is (= (test-parse :clj-expr "(println \\, \\;)")
-           '(clojure.core/println \, \;)))))
+           '(println \, \;)))))
 
 (deftest paren-tests
   (testing "parens inside of a string are NOT a clj-expr"
     (is (= (test-parse :clj-expr "(prn \"a string (with parens)\")")
-           '(clojure.core/prn "a string (with parens)")))
+           '(prn "a string (with parens)")))
     (is (= (test-parse :clj-expr "(prn \"a string with just a closing paren)\")")
-           '(clojure.core/prn "a string with just a closing paren)"))))
+           '(prn "a string with just a closing paren)"))))
   (testing "paren character literals don't break things"
     (is (= (test-parse :clj-expr "(prn \\()")
-           '(clojure.core/prn \()))
+           '(prn \()))
     (is (= (test-parse :clj-expr "(prn \\))")
-           '(clojure.core/prn \))))
+           '(prn \))))
     (is (= (test-parse :clj-expr "(prn \\( (+ 1 1) \\))")
-           '(clojure.core/prn \( (clojure.core/+ 1 1) \))))))
+           '(prn \( (+ 1 1) \))))))
 
 (deftest vector-tests
   (testing "vectors are a thing"
     (is (= (test-parse :clj-expr "(prn [1 2 3 \\a :b \"c\"])")
-           '(clojure.core/prn [1 2 3 \a :b "c"]))))
+           '(prn [1 2 3 \a :b "c"]))))
   (testing "vectors can have commas in them"
     (is (= (test-parse :clj-expr "(prn [1, 2, 3])")
-           '(clojure.core/prn [1 2 3])))))
+           '(prn [1 2 3])))))
 
 (deftest map-tests
   (testing "maps are a thing"
     (is (= (test-parse :clj-expr "(prn {:a 1 :b 2 :c 3})")
-           '(clojure.core/prn {:a 1 :b 2 :c 3}))))
+           '(prn {:a 1 :b 2 :c 3}))))
   (testing "maps can have commas in them"
     (is (= (test-parse :clj-expr "(prn {:a 1, :b 2, :c 3})")
-           '(clojure.core/prn {:a 1 :b 2 :c 3})))))
+           '(prn {:a 1 :b 2 :c 3})))))
 
 (deftest set-tests
   (testing "sets are a thing"
     (is (= (test-parse :clj-expr "(prn #{1 2 3})")
-           '(clojure.core/prn #{1 2 3}))))
+           '(prn #{1 2 3}))))
   (testing "sets can have commas in them"
     (is (= (test-parse :clj-expr "(prn #{1, 2, 3})")
-           '(clojure.core/prn #{1 2 3})))))
+           '(prn #{1 2 3})))))
 
 (deftest nesting-things
   (testing "things can be nested and it won't break shit"
     (is (= (test-parse :clj-expr "(prn [1 2 [3 4] 5])")
-           '(clojure.core/prn [1 2 [3 4] 5])))
+           '(prn [1 2 [3 4] 5])))
     (is (= (test-parse :clj-expr "(prn #{1 2 #{3 4} 5})")
-           '(clojure.core/prn #{1 2 #{3 4} 5})))
+           '(prn #{1 2 #{3 4} 5})))
     (is (= (test-parse :clj-expr "(prn (+ 1 [2 {3 #{4 5}}]))")
-           '(clojure.core/prn (clojure.core/+ 1 [2 {3 #{4 5}}]))))))
+           '(prn (+ 1 [2 {3 #{4 5}}]))))))
 

--- a/test/alda/parser/code_blocks_test.clj
+++ b/test/alda/parser/code_blocks_test.clj
@@ -1,0 +1,12 @@
+(ns alda.parser.code-blocks-test
+  (:require [clojure.test :refer :all]
+            [alda.test-helpers :refer (test-parse)]))
+
+(deftest code-block-tests
+  (testing "anything between [square brackets] is a code block"
+    (is (= (test-parse :code-block "[ c d e f c/e/g ]")
+           '(alda.lisp/code-block " c d e f c/e/g ")))
+    (is (= (test-parse :code-block "[aoeuaoeuaoeuaoe]")
+           '(alda.lisp/code-block "aoeuaoeuaoeuaoe")))
+    (is (= (test-parse :code-block "[c d [e f] g]")
+           '(alda.lisp/code-block "c d [e f] g")))))


### PR DESCRIPTION
This PR implements the `alda-code` function discussed in #104, as well as code block literals, as a stepping stone to implementing repeats (#7).

Code blocks are captured in the grammar as anything between `[ square brackets ]`. At the moment, they are essentially ignored when the score is evaluated -- they simply evaluate to strings. 

I plan to implement repeats as an alda.lisp function `repeat-code` that will take a string of text, repeat it a given number of times, and evaluate it using `alda-code`. There will be some syntactic sugar in the form of `xN` (where `N` is the number of times to repeat) and/or `||:  code here  :||N` which will be parsed as a call to `repeat-code`.