### PR TITLE
Adjusted CRAM implementation

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -21,7 +21,7 @@
          '[alda.lisp        :refer :all]
          '[str-to-argv      :refer (split-args)])
 
-; version number is stored in alda.version 
+; version number is stored in alda.version
 (bootlaces! alda.version/-version-)
 
 (task-options!
@@ -44,6 +44,7 @@
                        alda.parser.octaves-test
                        alda.parser.score-test
                        alda.lisp.attributes-test
+                       alda.lisp.cram-test
                        alda.lisp.chords-test
                        alda.lisp.duration-test
                        alda.lisp.global-attributes-test
@@ -58,8 +59,8 @@
 
 (deftask alda
   "Run Alda CLI tasks.
-   
-   Whereas running `bin/alda <cmd> <args>` will use the latest deployed 
+
+   Whereas running `bin/alda <cmd> <args>` will use the latest deployed
    version of Alda, running this task (`boot alda -x '<cmd> <args>'`)
    will use the current (local) version of this repo."
   [x execute ARGS str "The Alda CLI task and args as a single string."]

--- a/doc/cram.md
+++ b/doc/cram.md
@@ -21,3 +21,9 @@ You can also include note-lengths on the notes *inside* of a cram, which will ha
 ```
 
 > By default, the first note of each cram expression is a quarter note.
+
+Crams can be nested. Each internal cram will take up the appropriate amount of space within the cram containing it.
+
+```
+{c e {g a b}}1 c
+```

--- a/src/alda/lisp/events/note.clj
+++ b/src/alda/lisp/events/note.clj
@@ -3,8 +3,6 @@
 
 (log/debug "Loading alda.lisp.events.note...")
 
-(def ^:dynamic *time-scaling* {})
-
 (defrecord Note [offset instrument volume track-volume panning midi-note pitch duration])
 
 (defn note*
@@ -24,37 +22,43 @@
                             pitch-fn
                             (duration ($duration instrument))
                             true)))
-  ([instrument pitch-fn {:keys [duration-fn slurred]} slur?]
+  ([instrument pitch-fn {:keys [duration-fn beats slurred]} slur?]
     (let [quant          (if (or slur? slurred) 1.0 ($quantization instrument))
-          time-scaling   (*time-scaling* instrument 1)
-          note-duration  (* (duration-fn ($tempo instrument)) time-scaling)
-          event          (map->Note
-                           {:offset       ($current-offset instrument)
-                            :instrument   instrument
-                            :volume       ($volume instrument)
-                            :track-volume ($track-volume instrument)
-                            :panning      ($panning instrument)
-                            :midi-note    (pitch-fn ($octave instrument) 
-                                                    ($key-signature instrument) 
-                                                    :midi true)
-                            :pitch        (pitch-fn ($octave instrument) 
-                                                    ($key-signature instrument))
-                            :duration     (* note-duration quant)})]
-      (add-event instrument event)
-      (set-last-offset instrument ($current-offset instrument))
-      (set-current-offset instrument (offset+ ($current-offset instrument)
-                                              note-duration))
-      (log/debug (format "%s plays at %s + %s for %s ms, at %.2f Hz."
-                         instrument
-                         ($current-marker instrument)
-                         (int (:offset (:offset event)))
-                         (int (:duration event))
-                         (:pitch event)))
-      event)))
+          note-duration  (duration-fn ($tempo instrument))
+          event          (when-not *beats-tally* 
+                           (map->Note
+                             {:offset       ($current-offset instrument)
+                              :instrument   instrument
+                              :volume       ($volume instrument)
+                              :track-volume ($track-volume instrument)
+                              :panning      ($panning instrument)
+                              :midi-note    (pitch-fn ($octave instrument) 
+                                                      ($key-signature instrument) 
+                                                      :midi true)
+                              :pitch        (pitch-fn ($octave instrument) 
+                                                      ($key-signature instrument))
+                              :duration     (* note-duration quant)}))]
+      (if event
+        (do
+          (add-event instrument event)
+          (set-last-offset instrument ($current-offset instrument))
+          (set-current-offset instrument (offset+ ($current-offset instrument)
+                                                  note-duration))
+          (log/debug (format "%s plays at %s + %s for %s ms, at %.2f Hz."
+                             instrument
+                             ($current-marker instrument)
+                             (int (:offset (:offset event)))
+                             (int (:duration event))
+                             (:pitch event)))
+          event)
+        (alter-var-root #'*beats-tally* + beats)))))
 
 (defmacro note
   [& args]
   `(doall
-     (for [instrument# *current-instruments*]
+     (for [instrument# (if (and *beats-tally*
+                                (not (empty? *current-instruments*)))
+                         [(first *current-instruments*)]
+                         *current-instruments*)]
        (binding [*current-instruments* #{instrument#}]
          (note* instrument# ~@args)))))

--- a/src/alda/lisp/events/rest.clj
+++ b/src/alda/lisp/events/rest.clj
@@ -8,23 +8,28 @@
 (defn pause*
   ([instrument]
     (pause* instrument (duration ($duration instrument))))
-  ([instrument {:keys [duration-fn] :as dur}]
+  ([instrument {:keys [duration-fn beats] :as dur}]
     {:pre [(map? dur)]}
-    (let [rest-duration  (duration-fn ($tempo instrument))]
-      (set-last-offset instrument ($current-offset instrument))
-      (set-current-offset instrument (offset+ ($current-offset instrument)
-                                              rest-duration))
-      (let [rest (Rest. ($last-offset instrument) instrument rest-duration)]
-        (log/debug (format "%s rests at %s + %s for %s ms."
-                           instrument
-                           ($current-marker instrument)
-                           (int (:offset ($last-offset instrument)))
-                           (int rest-duration)))
-        rest))))
+    (if *beats-tally*
+      (alter-var-root #'*beats-tally* + beats)
+      (let [rest-duration (duration-fn ($tempo instrument))]
+        (set-last-offset instrument ($current-offset instrument))
+        (set-current-offset instrument (offset+ ($current-offset instrument)
+                                                rest-duration))
+        (let [rest (Rest. ($last-offset instrument) instrument rest-duration)]
+          (log/debug (format "%s rests at %s + %s for %s ms."
+                             instrument
+                             ($current-marker instrument)
+                             (int (:offset ($last-offset instrument)))
+                             (int rest-duration)))
+          rest)))))
 
 (defmacro pause
   [& args]
   `(doall
-     (for [instrument# *current-instruments*]
+     (for [instrument# (if (and *beats-tally*
+                                (not (empty? *current-instruments*)))
+                         [(first *current-instruments*)]
+                         *current-instruments*)]
        (binding [*current-instruments* #{instrument#}]
          (pause* instrument# ~@args)))))

--- a/src/alda/lisp/model/attribute.clj
+++ b/src/alda/lisp/model/attribute.clj
@@ -53,12 +53,11 @@
                                       old-val#
                                       new-val#)))
                  (AttributeChange. instrument# ~(keyword attr-name)
-
                                    old-val# new-val#))))))
       `(defn ~getter-fn
          ([] (~getter-fn (first *current-instruments*)))
          ([instrument#] (-> (*instruments* instrument#) ~kw-name)))
-       (concat 
+       (concat
          (for [fn-name fn-names]
            `(defn ~fn-name [x#]
               (set-attribute ~(keyword attr-name) x#)))

--- a/src/alda/lisp/model/duration.clj
+++ b/src/alda/lisp/model/duration.clj
@@ -5,6 +5,12 @@
 
 (declare set-duration)
 
+; used by CRAM to proportionately expand or shrink the duration of a group of
+; events; initial value: 1
+(declare ^:dynamic *time-scaling*)
+; used by CRAM to calculate *time-scaling*; initial value: nil
+(declare ^:dynamic *beats-tally*)
+
 (defn note-length
   "Converts a number, representing a note type, e.g. 4 = quarter, 8 = eighth,
    into a number of beats. Handles dots if present."
@@ -36,6 +42,7 @@
                                  (conj [components] false))
         beats (apply + note-lengths)]
     (set-duration beats)
-    {:duration-fn (fn [tempo] (float (* beats (/ 60000 tempo))))
+    {:duration-fn (fn [tempo]
+                    (float (* beats (/ 60000 tempo) *time-scaling*)))
      :slurred slurred
      :beats beats}))

--- a/src/alda/lisp/model/offset.clj
+++ b/src/alda/lisp/model/offset.clj
@@ -1,6 +1,8 @@
 (ns alda.lisp.model.offset)
 (in-ns 'alda.lisp)
 
+(require '[alda.util :refer (=%)])
+
 (log/debug "Loading alda.lisp.model.offset...")
 
 (declare ^:dynamic *events*
@@ -38,8 +40,8 @@
   [& offsets]
   (if (and (every? #(instance? alda.lisp.RelativeOffset %) offsets)
            (apply = (map :marker offsets)))
-    (apply == (map :offset offsets))
-    (apply == (map absolute-offset offsets))))
+    (apply =% (map :offset offsets))
+    (apply =% (map absolute-offset offsets))))
 
 ;;;
 

--- a/src/alda/lisp/score.clj
+++ b/src/alda/lisp/score.clj
@@ -21,6 +21,8 @@
     (init #'*score-text* "")
     (init #'*events* {:start {:offset (AbsoluteOffset. 0), :events []}})
     (init #'*global-attributes* {})
+    (init #'*time-scaling* 1)
+    (init #'*beats-tally* nil)
     (init #'*instruments* {})
     (init #'*current-instruments* #{})
     (init #'*nicknames* {})))

--- a/src/alda/util.clj
+++ b/src/alda/util.clj
@@ -22,6 +22,15 @@
      (when (seq ~(second binding))
        @done#)))
 
+(defmacro resetting [vars & body]
+  (if (seq vars)
+    (let [[x & xs] vars]
+      `(let [before# ~x
+             result# (resetting ~xs ~@body)]
+         (alter-var-root (var ~x) (constantly before#))
+         result#))
+    `(do ~@body)))
+
 (defn strip-nil-values
   "Strip `nil` values from a map."
   [hsh]
@@ -59,6 +68,12 @@
       (if (.startsWith position-str ":")
         (keyword (subs position-str 1))
         (keyword position-str)))))
+
+(defn =%
+  "Returns true if all arguments are within 0.01 of each other."
+  [& xs]
+  (let [[x & xs] (sort xs)]
+    (apply <= x (conj (vec xs) (+ x 0.01)))))
 
 (defn set-timbre-level!
   []

--- a/test/alda/lisp/cram_test.clj
+++ b/test/alda/lisp/cram_test.clj
@@ -1,0 +1,50 @@
+(ns alda.lisp.cram-test
+  (:require [clojure.test :refer :all]
+            [alda.lisp :refer :all]
+            [alda.util :refer (=%)]))
+
+(use-fixtures :each
+  (fn [run-tests]
+    (score*)
+    (part* "piano")
+    (run-tests)))
+
+(deftest cram-tests-1
+  (testing "a cram event with equally distributed notes:"
+    (let [start  ($current-offset)
+          _      (cram (note (pitch :c) :slur)
+                       (note (pitch :d) :slur)
+                       (note (pitch :e) :slur)
+                       ; a half note at 120 bpm = 1000 ms
+                       (duration (note-length 2)))
+          events (get-in *events* [($current-marker) :events])]
+      (testing "the first note should be placed at the current offset"
+        (let [earliest-note (apply min-key #(-> % :offset :offset) events)
+              offset        (:offset earliest-note)]
+          (is (offset= start offset))))
+      (testing "should bump :current-offset forward by its duration"
+        (is (offset= (offset+ start 1000) ($current-offset))))
+      (testing "the notes in a cram should be divided evenly across its duration"
+        (every? (fn [{:keys [duration]}] (=% duration 166.6666)) events)))))
+
+(deftest cram-tests-2
+  (testing "a cram event with no duration provided:"
+    (set-duration 4) ; a whole note at 120 bpm = 2000 ms
+    (let [start  ($current-offset)
+          _      (cram (note (pitch :c) :slur)
+                       (note (pitch :g) :slur))
+          events (get-in *events* [($current-marker) :events])]
+      (testing "should use the instrument's duration attribute value"
+        (is (offset= (offset+ start 2000) ($current-offset)))
+        (is (every? (fn [{:keys [duration]}] (=% duration 1000.0)) events))))))
+
+(deftest cram-tests-3
+  (testing "a cram event with a variety of note lengths:"
+    (cram (note (pitch :c) :slur) ; 250 ms
+          (note (pitch :d) (duration (note-length 2)) :slur) ; 500 ms
+          (note (pitch :e) (duration (note-length 4)) :slur) ; 250 ms
+          (duration (note-length 2))) ; total length = 1000 ms
+    (let [events (get-in *events* [($current-marker) :events])
+          offsets (sort (map :duration events))]
+      (testing "notes in a cram scale in proportion to one another"
+        (is (= [250.0 250.0 500.0] offsets))))))

--- a/test/alda/lisp/notes_test.clj
+++ b/test/alda/lisp/notes_test.clj
@@ -1,6 +1,5 @@
 (ns alda.lisp.notes-test
   (:require [clojure.test :refer :all]
-            [clojure.pprint :refer :all]
             [alda.lisp :refer :all]))
 
 (use-fixtures :each

--- a/test/alda/parser/events_test.clj
+++ b/test/alda/parser/events_test.clj
@@ -57,6 +57,20 @@
                 (alda.lisp/note (alda.lisp/pitch :f))))))))
 
 (deftest marker-tests
-  (is (= (test-parse :marker "%chorus") '(alda.lisp/marker "chorus")))
-  (is (= (test-parse :at-marker "@verse-1") '(alda.lisp/at-marker "verse-1"))))
+  (testing "markers"
+    (is (= (test-parse :marker "%chorus") '(alda.lisp/marker "chorus")))
+    (is (= (test-parse :at-marker "@verse-1") '(alda.lisp/at-marker "verse-1")))))
 
+(deftest cram-tests
+  (testing "crams"
+    (is (= (test-parse :cram "{c d e}")
+           '(alda.lisp/cram
+              (alda.lisp/note (alda.lisp/pitch :c))
+              (alda.lisp/note (alda.lisp/pitch :d))
+              (alda.lisp/note (alda.lisp/pitch :e)))))
+    (is (= (test-parse :cram "{c d e}2")
+           '(alda.lisp/cram
+              (alda.lisp/note (alda.lisp/pitch :c))
+              (alda.lisp/note (alda.lisp/pitch :d))
+              (alda.lisp/note (alda.lisp/pitch :e))
+              (alda.lisp/duration (alda.lisp/note-length 2)))))))

--- a/test/alda/test_helpers.clj
+++ b/test/alda/test_helpers.clj
@@ -20,3 +20,4 @@
   (first (for [[id instrument] *instruments*
                :when (.startsWith id (str inst-name \-))]
            instrument)))
+

--- a/test/examples/poly.alda
+++ b/test/examples/poly.alda
@@ -13,9 +13,6 @@ midi-woodblock:
   {c {c c c c c} c}
   {c {c c c c c c} c}
   {c {c c c c c c c} c}
-  {c {c c {c c c {c c c c {c c c c c {c c c c c c {c c c c c c c}}}}}}}
-  {c {c c {c c c {c c c c {c c c c c {c c c c c c {c c c c c c c {c c c c c c c c}}}}}}}}
-  {c {c c {c c c {c c c c {c c c c c {c c c c c c {c c c c c c c {c c c c c c c c {c c c c c c c c c}}}}}}}}}
 midi-agogo:
   o3
   r1


### PR DESCRIPTION
Fixes #124 (bug w/ nested crams), but unfortunately not #123 (improve cram perf), even though that's what I set out to do on this branch :persevere: 

The original idea I had was that we could gain some perf by not dry-running the entire body in the `cram` macro just to get the duration, resetting everything and then evaluating it for real. This PR takes some of the work out of the initial dry-run -- I added a `*beats-tally*` dynamic var, along with logic in the `note`, `pause` and `chord` events that looks at whether or not `*beats-tally*` is nil, and acts accordingly, either doing what it normally does, or short-circuiting and just adding to the beats tally. The adjusted implementation of the `cram` macro turns `*beats-tally*` on (setting it to 0), sets the duration to 1, tallies up the beats in the `body`, then resets and evaluates the body for real.

In benchmarking this against `poly.alda`, comparing this branch vs. master, there is essentially no difference whatsoever in performance. On a whim, I tried commenting out the 3 lines in `poly.alda` involving tons of nesting, and performance improved dramatically. So, my new theory is that nesting crams more than a few times causes a significant bottleneck -- it's probably exponential.

On the plus side, I think this code is a little bit clearer, and once I implemented it this way, fixing bug #124 was a cinch. I also added some tests, and documentation that it's possible to nest crams.