### PR TITLE
REPL help system

### DIFF
--- a/doc/alda-repl.md
+++ b/doc/alda-repl.md
@@ -6,3 +6,6 @@ To start the Alda REPL, run:
 
     alda repl
 
+At the REPL prompt, you can either enter Alda code, or use one of the available built-in commands, which start with a colon.
+
+For a list of available commands, enter `:help`.

--- a/src/alda/repl.clj
+++ b/src/alda/repl.clj
@@ -2,7 +2,7 @@
   (:require [alda.version                 :refer (-version-)]
             [alda.lisp                    :refer :all]
             [alda.sound                   :refer (set-up! tear-down!)]
-            [alda.repl.core               :as    repl :refer (*repl-reader* 
+            [alda.repl.core               :as    repl :refer (*repl-reader*
                                                               *parsing-context*)]
             [alda.repl.commands           :refer (repl-command)]
             [boot.from.io.aviso.ansi      :refer :all]
@@ -26,26 +26,29 @@
        "         repl session"))
 
 (def banner
-  (str (blue ascii-art)
+  (str (blue ascii-art) \newline
        \newline
+       (cyan text-below-ascii-art) \newline
        \newline
-       (cyan text-below-ascii-art)))
+       (bold-white "Type :help for a list of available commands.")))
 
 (defn start-repl! []
   (println)
   (println banner \newline)
   (alter-var-root #'*parsing-context* (constantly :part))
-  (alter-var-root #'*repl-reader* (constantly (doto (ConsoleReader.) 
+  (alter-var-root #'*repl-reader* (constantly (doto (ConsoleReader.)
                                                 (.setExpandEvents false)
                                                 (.setPrompt "> "))))
   (let [done? (atom false)]
     (print "Loading MIDI synth... ")
     (set-up! :midi)
-    (println "done." \newline)
+    (println "done.")
     (score*) ; initialize a new score
     (binding [*out* (.getOutput *repl-reader*)]
       (repl/set-prompt!)
-      (while-let [alda-code (when-not @done? (.readLine *repl-reader*))]
+      (while-let [alda-code (when-not @done?
+                              (println)
+                              (.readLine *repl-reader*))]
         (try
           (cond
             (re-find #"^\s*$" alda-code)

--- a/src/alda/repl/commands.clj
+++ b/src/alda/repl/commands.clj
@@ -32,15 +32,22 @@
 (defmethod repl-command :default [_ _]
   (huh?))
 
+(def repl-commands (atom {}))
+
 (defmacro defcommand [cmd-name & things]
-  (let [[args & body]  (if (string? (first things)) (rest things) things)
+  (let [[doc args & body]  (if (string? (first things))
+                             things
+                             (cons "" things))
         [rest-of-line] args]
-    `(defmethod repl-command ~(str cmd-name)
-       [_# ~rest-of-line]
-       ~@body)))
+    `(do
+       (defmethod repl-command ~(str cmd-name)
+         [_# ~rest-of-line]
+         ~@body)
+       (swap! repl-commands assoc ~(str cmd-name) ~doc))))
 
 (defcommand new
-  "Create a new score or part."
+  ; TODO: implement ":new part" and then update the docstring
+  "Create a new score."
   [rest-of-line]
   (cond
     (contains? #{"" "score"} rest-of-line)
@@ -66,7 +73,20 @@
 
 (defcommand play
   "Plays the current score.
-   Can take `from` and `to` arguments, in the form of markers or mm:ss times."
+
+   Can take optional `from` and `to` arguments, in the form of markers or mm:ss times.
+
+   Without arguments, will play the entire score from beginning to end.
+
+   Example usage:
+
+     :play
+     :play from 0:05
+     :play to 0:10
+     :play from 0:05 to 0:10
+     :play from guitarIn
+     :play to verse
+     :play from verse to bridge"
   [rest-of-line]
   (if (empty? *score-text*)
     (println "You must first create or :load a score.")
@@ -76,7 +96,12 @@
         (repl/interpret! *score-text*)))))
 
 (defcommand load
-  "Load an Alda score into the current REPL session."
+  "Loads an Alda score into the current REPL session.
+
+   Usage:
+
+     :load test/examples/bach_cello_suite_no_1.alda
+     :load /Users/rick/Scores/love_is_alright_tonite.alda"
   [filename]
   (letfn [(confirm-load []
             (println "Are you sure you want to load" (str filename \?))
@@ -102,13 +127,48 @@
             (if (confirm-load)
               (load-score score-text)
               (println "File load aborted.")))]
-    (if-let [score-text (try
-                          (slurp filename)
-                          (catch java.io.FileNotFoundException e nil))]
-      (if (dirty?)
-        (do
-          (println "You have made changes to the current score that will be"
-                   "lost if you load" (str filename "."))
-          (confirm-and-load-score score-text))
-        (load-score score-text))
-      (println "File not found:" filename))))
+    (if (empty? filename)
+      (println "Load what?")
+      (if-let [score-text (try
+                            (slurp filename)
+                            (catch java.io.FileNotFoundException e nil))]
+        (if (dirty?)
+          (do
+            (println "You have made changes to the current score that will be"
+                     "lost if you load" (str filename "."))
+            (confirm-and-load-score score-text))
+          (load-score score-text))
+        (println "File not found:" filename)))))
+
+(defn- parse-docstring
+  "Parses the docstring of a REPL command defined in this namespace into two
+   things -- a brief description of what it does (the first line of the
+   docstring) and a more detailed description (any subsequent lines)."
+  [docstring]
+  (let [[description & details] (str/split docstring #"\n")]
+    [description (when details (str/join \newline details))]))
+
+(defn generate-help-text
+  ([]
+    (str "For commands marked with (*), more detailed information about the "
+         "command is available via the :help command.\n\ne.g. :help play\n\n"
+         "Available commands:\n\n"
+         (str/join \newline
+                   (for [[cmd docstring] @repl-commands
+                         :let [[desc details] (parse-docstring docstring)]]
+                     (str "    :" cmd \tab (str desc (when details " (*)")))))))
+  ([subject]
+    (if-let [docstring (get @repl-commands subject)]
+      (let [[description details] (parse-docstring docstring)]
+        (str \: subject \newline
+             \newline
+             description
+             (when details (str \newline details))))
+      (format "Help is not available on '%s'." subject))))
+
+(defcommand help
+  "Display this help text."
+  [subject]
+  (if (empty? subject)
+    (println (generate-help-text))
+    (println (generate-help-text subject))))


### PR DESCRIPTION
Closes #66.

This PR adds a rudimentary help system that dynamically uses information from the docstrings of the REPL commands defined in `alda.repl.commands`.

`:help` prints a list of available commands, with the first line of each docstring as a brief description of what the command does. 

`:help <command>` prints the full docstring of a command.