### PR TITLE
Millisecond/second note durations

### DIFF
--- a/doc/notes.md
+++ b/doc/notes.md
@@ -1,24 +1,24 @@
 # Notes
 
-Alda's syntax for **notes** is heavily inspired by [MML](http://www.nullsleep.com/treasure/mck_guide). 
+Alda's syntax for **notes** is heavily inspired by [MML](http://www.nullsleep.com/treasure/mck_guide).
 
 ## Components
 
 ### Octave
 
-Western music theory divides pitches into repeating groups of 12 notes, e.g. (ascending) `c c# d d# e f f# g g# a a# b (next octave) c c# d`, etc. The combination of the letter pitch (e.g. C#) and the octave determines the frequency of the note in Hz. Octave is expressed as a number, typically between 1 and 7, corresponding to [scientific pitch notation](http://en.wikipedia.org/wiki/Scientific_pitch_notation). For example, middle C and A440 are both in octave 4, which is the default octave in Alda. Just like in MML, the octave is set separately from the notes themselves - i.e. it's not "attached to" or "part of" the note, rather, each note looks at the current octave in order to determine its pitch. 
+Western music theory divides pitches into repeating groups of 12 notes, e.g. (ascending) `c c# d d# e f f# g g# a a# b (next octave) c c# d`, etc. The combination of the letter pitch (e.g. C#) and the octave determines the frequency of the note in Hz. Octave is expressed as a number, typically between 1 and 7, corresponding to [scientific pitch notation](http://en.wikipedia.org/wiki/Scientific_pitch_notation). For example, middle C and A440 are both in octave 4, which is the default octave in Alda. Just like in MML, the octave is set separately from the notes themselves - i.e. it's not "attached to" or "part of" the note, rather, each note looks at the current octave in order to determine its pitch.
 
 You can set the octave two ways:
 
-`o5` sets the octave to octave 5. Any integer can follow o. 
+`o5` sets the octave to octave 5. Any integer can follow o.
 
 `<` decreases current octave by 1. `>` increases current octave by 1.
 
-### Duration 
+### Duration
 
-Duration in Alda (as in MML) is expressed in note lengths from standard music notation, in number form. 4 is a quarter note, 2 is a half note, 1 is a whole note, etc. 
+Duration in Alda (as in MML) is typically expressed in note lengths from standard music notation, in number form. 4 is a quarter note, 2 is a half note, 1 is a whole note, etc.
 
-Any number of dots can be added to a note duration, which has the same effect as in standard music notation - it essentially adds half of the note duration to the total duration of the note. 
+Any number of dots can be added to a note duration, which has the same effect as in standard music notation - it essentially adds half of the note duration to the total duration of the note.
 
 e.g.
 
@@ -29,25 +29,32 @@ e.g.
 Note durations can also be added together using the tie syntax, `~`. (`4~4` = two quarter notes tied together, 2 beats total.)
 
 
-Alda keeps track of both the current octave and the current default note duration as notes are processed sequentially in a score. Each time a note duration is specified, that duration becomes the new default note duration. Each note that follows, when no note duration is specified, will have the default note duration. At the beginning of each instrument part, the default octave is 4 and the default note duration is 4 (i.e. a quarter note, 1 beat). 
+Alda keeps track of both the current octave and the current default note duration as notes are processed sequentially in a score. Each time a note duration is specified, that duration becomes the new default note duration. Each note that follows, when no note duration is specified, will have the default note duration. At the beginning of each instrument part, the default octave is 4 and the default note duration is 4 (i.e. a quarter note, 1 beat).
 
 #### Advanced Rhythms
 
-* A special feature of Alda is that you can use non-standard numbers as note durations. For example, 6 is a note that lasts 1/6 of a measure in 4/4 time. In standard notation, there is no such thing as a "sixth note," but this note length would be commonly expressed as one note in a quarter note triplet; in Alda, a "6th note" doesn't necessarily need to be part of a triplet, however, which raises interesting rhythmic possibilities. 
+* A special feature of Alda is that you can use non-standard numbers as note durations. For example, 6 is a note that lasts 1/6 of a measure in 4/4 time. In standard notation, there is no such thing as a "sixth note," but this note length would be commonly expressed as one note in a quarter note triplet; in Alda, a "6th note" doesn't necessarily need to be part of a triplet, however, which raises interesting rhythmic possibilities.
 
 * Alda also has an alternate way of specifying rhythms called [CRAM](cram.md).
 
-### Letter pitch 
+* Note lengths can also be expressed in milliseconds and seconds, which can optionally be mixed and matched with standard note lengths:
+
+        c350ms    # a C note lasting 350 milliseconds
+        d2s       # a D note lasting 2 seconds
+        e2s~200ms # an E note lasting 2 seconds + 200 milliseconds
+        f300ms~4. # an F note lasting 300 milliseconds + a dotted quarter note
+
+### Letter pitch
 
 A note in Alda is expressed as a letter from a-g, any number of accidentals (optional), and a note duration (also optional).
 
-Flats and sharps will decrease/increase the pitch by one half step, e.g. C + 1/2 step = C#. Flats and sharps are expressed in Alda as `-` and `+`, and you can have multiple sharps or multiple flats, or even combine them, if you'd like. e.g. `c++` = C double-sharp = D. 
+Flats and sharps will decrease/increase the pitch by one half step, e.g. C + 1/2 step = C#. Flats and sharps are expressed in Alda as `-` and `+`, and you can have multiple sharps or multiple flats, or even combine them, if you'd like. e.g. `c++` = C double-sharp = D.
 
 As an alternative to placing flats and sharps on every note that needs them, you may prefer to set the [key signature](attributes.md#key-signature), which will add the necessary sharps/flats to any note that needs them in order to match the key. See below for an example of using a key signature.
 
 To overwrite the flat/sharp specified by a key signature, you can include an accidental, i.e. `-` or `+` to make the note flat or sharp. You can also override the key signature and force a note to be natural with `=`, i.e. `c=` is a C natural regardless of what key you are in.
 
-## Example 
+## Example
 
 The following is a 1-octave B major scale, ascending and descending, starting in octave 4:
 

--- a/grammar/alda.bnf
+++ b/grammar/alda.bnf
@@ -32,12 +32,19 @@ pitch                   = !name #"[a-g]" accidental*
 flat                    = "-"
 sharp                   = "+"
 natural                 = "="
-duration                = note-length <ows> barline? <ows> subduration* slur?
-<subduration>           = tie <ows> barline? <ows> note-length <ows> barline? <ows>
+
+    (* duration *)
+
+duration                = (note-length | seconds | milliseconds)
+                          <ows> barline? <ows> subduration* slur?
+<subduration>           = tie <ows> barline? <ows>
+                          (note-length | seconds | milliseconds) <ows>
+                          barline? <ows>
+
+seconds                 = positive-number <"s">
+milliseconds            = positive-number <"ms">
+
 note-length             = positive-number dots?
-number                  = positive-number | negative-number
-positive-number         = #"[0-9]+"
-negative-number         = #"-[0-9]+"
 dots                    = #"\.+"
 <tie>                   = <"~">
 slur                    = <"~">
@@ -54,12 +61,12 @@ barline                 = <"|"> <ows>
 
     (* inline clojure expressions *)
 
-clj-character           = <"\\"> ( "newline" / "space" / "tab" / 
+clj-character           = <"\\"> ( "newline" / "space" / "tab" /
                                    "formfeed" / "backspace" / "return" /
                                    #"(o|u)\d{4}" / #"." )
 
 clj-string              = <"\""> inside-clj-string* <"\"">
-<inside-clj-string>     = !"\"" #".|\n|\r" | "\\\"" 
+<inside-clj-string>     = !"\"" #".|\n|\r" | "\\\""
 
 clj-expr                = <"("> inside-clj-expr* <")"> <ows>
 <inside-clj-expr>       = !( "(" | ")" | "\"" | "\\" )
@@ -74,6 +81,12 @@ code-block-no-ws        = <"["> inside-code-block* <"]">
     (* cram - rhythmic section *)
 
 cram                    = <"{"> event* <"}"> duration? <ows>
+
+    (* numbers *)
+
+number                  = positive-number | negative-number
+positive-number         = #"[0-9]+"
+negative-number         = #"-[0-9]+"
 
     (* comments & whitespace *)
 

--- a/src/alda/lisp/attributes.clj
+++ b/src/alda/lisp/attributes.clj
@@ -23,7 +23,11 @@
 (defattribute duration
   "Default note duration in beats."
   :initial-val 1
-  :fn-name set-duration)
+  :fn-name set-duration
+  :transform (fn [val]
+               (constantly (if (map? val)
+                             (:value val)
+                             val))))
 
 (defattribute octave
   "Current octave. Used to calculate the pitch of notes."

--- a/src/alda/lisp/events/chord.clj
+++ b/src/alda/lisp/events/chord.clj
@@ -39,8 +39,8 @@
                (repeat `(swap! ~offsets conj ($current-offset ~instrument))))
              [`(set-last-offset ~instrument ~start)
               `(set-current-offset ~instrument (apply (partial min-key :offset)
-                                                  (remove #(offset= % ~start)
-                                                          (deref ~offsets))))
+                                                      (remove #(offset= % ~start)
+                                                              (deref ~offsets))))
               `(let [chord#
                      (Chord. (take-last ~num-of-events
                                         (get-in *events*

--- a/src/alda/lisp/events/note.clj
+++ b/src/alda/lisp/events/note.clj
@@ -25,17 +25,17 @@
   ([instrument pitch-fn {:keys [duration-fn beats slurred]} slur?]
     (let [quant          (if (or slur? slurred) 1.0 ($quantization instrument))
           note-duration  (duration-fn ($tempo instrument))
-          event          (when-not *beats-tally* 
+          event          (when-not *beats-tally*
                            (map->Note
                              {:offset       ($current-offset instrument)
                               :instrument   instrument
                               :volume       ($volume instrument)
                               :track-volume ($track-volume instrument)
                               :panning      ($panning instrument)
-                              :midi-note    (pitch-fn ($octave instrument) 
-                                                      ($key-signature instrument) 
+                              :midi-note    (pitch-fn ($octave instrument)
+                                                      ($key-signature instrument)
                                                       :midi true)
-                              :pitch        (pitch-fn ($octave instrument) 
+                              :pitch        (pitch-fn ($octave instrument)
                                                       ($key-signature instrument))
                               :duration     (* note-duration quant)}))]
       (if event

--- a/src/alda/lisp/model/duration.clj
+++ b/src/alda/lisp/model/duration.clj
@@ -11,20 +11,42 @@
 ; used by CRAM to calculate *time-scaling*; initial value: nil
 (declare ^:dynamic *beats-tally*)
 
+(defn ms
+  "Represents a duration value specified in milliseconds.
+
+   Wraps it in a map to give the `duration` function context that we're talking
+   about milliseconds, not beats."
+  [n]
+  {:type :milliseconds
+   :value n})
+
 (defn note-length
   "Converts a number, representing a note type, e.g. 4 = quarter, 8 = eighth,
-   into a number of beats. Handles dots if present."
+   into a number of beats. Handles dots if present.
+
+   Wraps the result in a map to give the `duration` function context that we're
+   talking about a number of beats."
   ([number]
-    (/ 4 number))
+    (note-length number {:dots 0}))
   ([number {:keys [dots]}]
-    (let [value (/ 4 number)]
-      (loop [total value, factor 0.5, dots dots]
-        (if (pos? dots)
-          (recur (+ total (* value factor)) (* factor 0.5) (dec dots))
-          total)))))
+   {:pre [(pos? number)]}
+    {:type :beats
+     :value (* (/ 4 number)
+               (- 2 (Math/pow 2 (- dots))))}))
 
 (defn duration
   "Combines a variable number of tied note-lengths into one.
+
+   Note-lengths can be expressed in beats or milliseconds. This distinction is
+   made via the :type key in the map. The number of beats/milliseconds is
+   provided via the :value key in the map.
+
+   e.g.
+   (note-length 1) => {:type :beats, :value 4}
+   (ms 4000)       => {:type :milliseconds, :value 4000}
+
+   To preserve backwards compatibility, a note-length expressed as a simple
+   number (not wrapped in a map) is interpreted as a number of beats.
 
    Barlines can be inserted inside of a duration -- these currently serve a
    purpose in the parse tree only, and evaluate to `nil` in alda.lisp. This
@@ -40,9 +62,21 @@
         [note-lengths slurred] (if (= (last components) :slur)
                                  (conj [(drop-last components)] true)
                                  (conj [components] false))
-        beats (apply + note-lengths)]
-    (set-duration beats)
+        note-lengths (map (fn [x] (if (map? x)
+                                    x
+                                    {:type :beats, :value x}))
+                          note-lengths)
+        beats (apply + (for [{:keys [type value]} note-lengths
+                             :when (= type :beats)]
+                         value))
+        ms    (apply + (for [{:keys [type value]} note-lengths
+                             :when (= type :milliseconds)]
+                         value))]
+    (when (pos? beats) (set-duration beats))
     {:duration-fn (fn [tempo]
-                    (float (* beats (/ 60000 tempo) *time-scaling*)))
+                    (+ (float (* beats
+                                 (/ 60000 tempo)
+                                 *time-scaling*))
+                       ms))
      :slurred slurred
      :beats beats}))

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -40,7 +40,7 @@
           :clj-expr          #(read-clj-expr %&)
           :code-block        #(list 'alda.lisp/code-block (second %))
           :code-block-no-ws  #(list :code-block-no-ws
-                                    (apply str 
+                                    (apply str
                                            (map (fn [x]
                                                   (if (list? x)
                                                     (str \[ (second x) \])
@@ -60,8 +60,10 @@
           :natural           (constantly :natural)
           :dots              #(hash-map :dots (count %))
           :note-length       #(list* 'alda.lisp/note-length %&)
+          :milliseconds      #(list 'alda.lisp/ms %)
+          :seconds           #(list 'alda.lisp/ms (* % 1000))
           :duration          #(list* 'alda.lisp/duration %&)
-          :pitch             (fn [letter & accidentals] 
+          :pitch             (fn [letter & accidentals]
                                (list* 'alda.lisp/pitch (keyword letter) accidentals))
           :note              #(list* 'alda.lisp/note %&)
           :rest              #(list* 'alda.lisp/pause %&)

--- a/test/alda/lisp/attributes_test.clj
+++ b/test/alda/lisp/attributes_test.clj
@@ -54,5 +54,5 @@
   (testing "note-length"
     (set-duration (note-length 2 {:dots 2}))
     (is (== ($duration) 3.5))
-    (set-duration (+ (note-length 1) (note-length 1)))
+    (duration (note-length 1) (note-length 1))
     (is (== ($duration) 8))))

--- a/test/alda/lisp/duration_test.clj
+++ b/test/alda/lisp/duration_test.clj
@@ -10,11 +10,11 @@
 
 (deftest duration-tests
   (testing "note-length converts note length to number of beats"
-    (is (== 1 (note-length 4)))
-    (is (== 1.5 (note-length 4 {:dots 1})))
-    (is (== 4 (note-length 1)))
-    (is (== 6 (note-length 1 {:dots 1})))
-    (is (== 7 (note-length 1 {:dots 2}))))
+    (is (== 1 (:value (note-length 4))))
+    (is (== 1.5 (:value (note-length 4 {:dots 1}))))
+    (is (== 4 (:value (note-length 1))))
+    (is (== 6 (:value (note-length 1 {:dots 1}))))
+    (is (== 7 (:value (note-length 1 {:dots 2})))))
   (testing "duration converts beats to ms"
     (let [{:keys [duration-fn]} (duration (note-length 4) :slur)]
       (is (== 1000 (duration-fn 60))))

--- a/test/alda/lisp/duration_test.clj
+++ b/test/alda/lisp/duration_test.clj
@@ -26,11 +26,25 @@
       (is (== 500 (duration-fn 120))))
     (let [{:keys [duration-fn]} (duration (note-length 4 {:dots 1}))]
       (is (== 750 (duration-fn 120)))))
+  (testing "duration can be described in milliseconds"
+    (let [{:keys [duration-fn]} (duration (ms 1000) :slur)]
+      (is (== 1000 (duration-fn 42))))
+    (let [{:keys [duration-fn]} (duration (ms 2000)
+                                          (ms 2000)
+                                          (ms 3500) :slur)]
+      (is (== 7500 (duration-fn 123)))))
+  (testing "note-lengths and millisecond values can be combined"
+    (let [{:keys [duration-fn]} (duration (ms 2000)
+                                          (note-length 2)
+                                          (ms 45) :slur)]
+      (is (== 4045 (duration-fn 60))))
+    (let [{:keys [duration-fn]} (duration (note-length 1 {:dots 1})
+                                          (ms 333) :slur)]
+      (is (== 3333 (duration-fn 120)))))
   (testing "barlines don't break duration"
     (let [{:keys [duration-fn]} (duration (note-length 4)
                                           (barline)
-                                          (note-length 4)
-                                          :slur)]
+                                          (note-length 4) :slur)]
       (is (== 2000 (duration-fn 60)))))
   (testing "quantization quantizes note durations"
     (set-attributes :tempo 120 :quant 100)

--- a/test/alda/parser/duration_test.clj
+++ b/test/alda/parser/duration_test.clj
@@ -12,14 +12,39 @@
     (is (= (test-parse :duration "2..")
            '(alda.lisp/duration (alda.lisp/note-length 2 {:dots 2}))))))
 
+(deftest millisecond-duration-tests
+  (testing "duration in milliseconds"
+    (is (= (test-parse :duration "400ms")
+           '(alda.lisp/duration (alda.lisp/ms 400))))
+    (is (= (test-parse :note "c450ms")
+           '(alda.lisp/note (alda.lisp/pitch :c)
+                            (alda.lisp/duration (alda.lisp/ms 450)))))))
+
+(deftest second-duration-tests
+  (testing "duration in seconds"
+    (is (= (test-parse :duration "5s")
+           '(alda.lisp/duration (alda.lisp/ms 5000))))
+    (is (= (test-parse :note "c2s")
+           '(alda.lisp/note (alda.lisp/pitch :c)
+                            (alda.lisp/duration (alda.lisp/ms 2000)))))))
+
 (deftest tie-and-slur-tests
   (testing "ties"
     (testing "ties"
       (is (= (test-parse :duration "1~2~4")
              '(alda.lisp/duration (alda.lisp/note-length 1)
                                   (alda.lisp/note-length 2)
-                                  (alda.lisp/note-length 4)))))
+                                  (alda.lisp/note-length 4))))
+      (is (= (test-parse :duration "500ms~350ms")
+             '(alda.lisp/duration (alda.lisp/ms 500)
+                                  (alda.lisp/ms 350))))
+      (is (= (test-parse :duration "5s~4~350ms")
+             '(alda.lisp/duration (alda.lisp/ms 5000)
+                                  (alda.lisp/note-length 4)
+                                  (alda.lisp/ms 350)))))
     (testing "slurs"
       (is (= (test-parse :duration "4~")
-             '(alda.lisp/duration (alda.lisp/note-length 4) :slur))))))
+             '(alda.lisp/duration (alda.lisp/note-length 4) :slur)))
+      (is (= (test-parse :duration "420ms~")
+             '(alda.lisp/duration (alda.lisp/ms 420) :slur))))))
 

--- a/test/examples/entropy.alda
+++ b/test/examples/entropy.alda
@@ -1,0 +1,31 @@
+(def REST-RATE 0.15)
+(def MS-LOWER 30)
+(def MS-UPPER 3000)
+(def MAX-OCTAVE 8)
+
+(defn random-note
+  "Plays a random note in a random octave, for a random number of
+  milliseconds.
+
+  May randomly decide to rest, instead, for a random number of milliseconds."
+  []
+  (let [ms (ms (rand-nth (range MS-LOWER MS-UPPER)))]
+    (if (< (rand) REST-RATE)
+      (pause (duration ms))
+      (let [o (rand-int (inc MAX-OCTAVE))
+            n [(keyword (str (rand-nth "abcdefg")))
+               (rand-nth [:sharp :flat :natural])]]
+       (octave o)
+       (note (apply pitch n) (duration ms))))))
+
+midi-electric-piano-1:
+  (panning 25)
+  (dotimes [_ 50] (random-note))
+
+midi-timpani:
+  (panning 50)
+  (dotimes [_ 50] (random-note))
+
+midi-celesta:
+  (panning 75)
+  (dotimes [_ 50] (random-note))


### PR DESCRIPTION
Closes #9 (the CRAM part of which has already been implemented).

A possible TODO before merging this: 

- ~~Add an algorithmic music example score utilizing a combination of millisecond/second note durations and inline Clojure code that will randomly generate pitches and millisecond note durations.~~  
:metal: done :metal: