### PR TITLE
Schedule custom events

### DIFF
--- a/doc/inline-clojure-code.md
+++ b/doc/inline-clojure-code.md
@@ -36,3 +36,19 @@ bassoon:
   (alda-code (apply str (repeatedly 5 #(str (rand-nth "abcdefg") \space))))
 ```
 
+## Scheduling custom events
+
+You might initially think that each Clojure expression is not evaluated until the point in time where it is situated in the score, but this is actually not the case. Clojure expressions *are* evaluated in score-order, but this happens very quickly during the brief period of time before the score is played. When the score is evaluated, essentially all it does is queue up a bunch of events (mostly notes being played), and it is during this period that your Clojure code will run.
+
+It is still possible, however to schedule custom events to occur at a specific time in the score, thanks to the `schedule` function.
+
+```
+piano:
+  (schedule #(println "playing c")) c8
+  (schedule #(println "playing d")) d
+  (schedule #(println "playing e")) e
+  (schedule #(println "playing f")) f
+  (schedule #(println "playing g")) g2
+```
+
+`schedule` takes a function as its argument. The function that you give it can be any Clojure function that takes zero arguments.

--- a/src/alda/lisp/events.clj
+++ b/src/alda/lisp/events.clj
@@ -4,6 +4,7 @@
             [alda.lisp.events.chord]
             [alda.lisp.events.voice]
             [alda.lisp.events.barline]
-            [alda.lisp.events.cram]))
+            [alda.lisp.events.cram]
+            [alda.lisp.events.fn]))
 (in-ns 'alda.lisp)
 

--- a/src/alda/lisp/events/fn.clj
+++ b/src/alda/lisp/events/fn.clj
@@ -1,0 +1,16 @@
+(ns alda.lisp.events.fn)
+(in-ns 'alda.lisp)
+
+(defrecord Function [offset function])
+
+(defn schedule
+  "Schedules an arbitrary function to be called at the current point in the
+   score (determined by the current instrument's marker and offset).
+
+   If there are multiple current instruments, the function will be executed
+   once for each instrument, at the marker + offset of that instrument."
+  [f]
+  (when-not *beats-tally*
+    (doseq [instrument *current-instruments*]
+      (let [event (Function. ($current-offset instrument) f)]
+        (add-event instrument event)))))

--- a/src/alda/lisp/model/event.clj
+++ b/src/alda/lisp/model/event.clj
@@ -8,9 +8,11 @@
 (defn add-event
   [instrument event]
   (let [marker (-> (*instruments* instrument) :current-marker)]
-    (alter-var-root #'*events* update-in [marker :events] (fnil conj []) event)))
+    (alter-var-root #'*events* update-in [marker :events] (fnil conj []) event)
+    event))
 
 (defn add-events
   [instrument events]
   (let [marker (-> (*instruments* instrument) :current-marker)]
-    (alter-var-root #'*events* update-in [marker :events] (fnil into []) events)))
+    (alter-var-root #'*events* update-in [marker :events] (fnil into []) events)
+    events))

--- a/src/alda/sound.clj
+++ b/src/alda/sound.clj
@@ -122,10 +122,12 @@
 (defn- score-length
   "Calculates the length of a score in ms."
   [{:keys [events] :as score}]
-  (if (and events (not (empty? events)))
-    (letfn [(note-end [{:keys [offset duration] :as note}] (+ offset duration))]
-      (apply max (map note-end events)))
-    0))
+  (let [events   (filter :duration events)
+        note-end (fn [{:keys [offset duration] :as note}]
+                   (+ offset duration))]
+    (if (and events (not (empty? events)))
+      (apply max (map note-end (filter :duration events)))
+      0)))
 
 (defn determine-audio-types
   [{:keys [instruments] :as score}]
@@ -178,7 +180,9 @@
                    :let [inst (-> instrument instruments)]]
       (at (+ begin offset)
           #(when @playing?
-             (play-event! event inst))
+             (if (= (type event) alda.lisp.Function)
+               ((:function event))
+               (play-event! event inst)))
           pool))
 
     (when-not async?

--- a/test/examples/printing.alda
+++ b/test/examples/printing.alda
@@ -1,0 +1,8 @@
+# This demonstrates the "schedule" function, which executes a Clojure function
+# at the moment in the score where the function was scheduled.
+
+trombone:
+  (schedule #(println "too")) c6
+  (schedule #(do (print "ma") (flush))) d12
+  (schedule #(println "ny")) e6
+  (schedule #(println "cooks")) g12~4


### PR DESCRIPTION
Closes #104.

This adds a "function" event type, which can be scheduled in a similar way to note events via the `alda.lisp/schedule` function.

I'm half-wondering if maybe it should be implemented as a macro instead, so that it can be used in a slightly cleaner way, i.e. `(schedule (println "hi!"))` instead of `(schedule #(println "hi!"))`, but I'm leaning toward it being a function, for the sake of simplicity, and in case we may want to add optional arguments of some kind in the future. Totally open to discussion, though.