### PR TITLE
Prompt for confirmation before discarding unsaved changes

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -102,6 +102,22 @@
                           alda.parser.examples-test
                           }})
 
+(deftask dev
+  "Runs the Alda server for development.
+
+   There is a middleware that reloads all the server namespaces before each
+   request, so that the server does not need to be restarted after making
+   changes."
+  []
+  (comp
+    (with-pre-wrap fs
+      (require 'alda.server)
+      (require 'alda.util)
+      ((resolve 'alda.util/set-timbre-level!) :debug)
+      ((resolve 'alda.server/start-server!) 27713)
+      fs)
+    (wait)))
+
 (deftask package
   "Builds an uberjar."
   []

--- a/client/src/alda/AldaServer.java
+++ b/client/src/alda/AldaServer.java
@@ -377,17 +377,19 @@ public class AldaServer {
     Parser p = Parsers.newParser(Parsers.defaultConfiguration());
     Map<?, ?> m = (Map<?, ?>) p.nextValue(pbr);
 
-    String status   = (String) m.get(newKeyword("status"));
-    String version  = (String) m.get(newKeyword("version"));
-    String filename = (String) m.get(newKeyword("filename"));
-    Long lineCount  = (Long) m.get(newKeyword("line-count"));
-    Long charCount  = (Long) m.get(newKeyword("char-count"));
+    String status      = (String) m.get(newKeyword("status"));
+    String version     = (String) m.get(newKeyword("version"));
+    String filename    = (String) m.get(newKeyword("filename"));
+    Boolean isModified = (Boolean) m.get(newKeyword("modified?"));
+    Long lineCount     = (Long) m.get(newKeyword("line-count"));
+    Long charCount     = (Long) m.get(newKeyword("char-count"));
     @SuppressWarnings("unchecked") List<Map<?, ?>> instruments =
       (List<Map<?, ?>>) m.get(newKeyword("instruments"));
 
     msg("Server status: " + status);
     msg("Server version: " + version);
     msg("Filename: " + (filename != null ? filename : "(new score)"));
+    msg("Modified: " + (isModified ? "yes" : "no"));
     msg("Line count: " + lineCount);
     msg("Character count: " + charCount);
     if (instruments.isEmpty()) {

--- a/client/src/alda/AldaServer.java
+++ b/client/src/alda/AldaServer.java
@@ -135,7 +135,8 @@ public class AldaServer {
     serverDown(false);
   }
 
-  private String doRequest(HttpRequestBase httpRequest) throws IOException {
+  private String doRequest(HttpRequestBase httpRequest)
+    throws IOException, UnsavedChangesException {
     try {
       ResponseHandler<String> responseHandler = new ResponseHandler<String>() {
         @Override
@@ -148,6 +149,13 @@ public class AldaServer {
           if (response.getFirstHeader("X-Alda-Version") == null) {
             throw new HttpResponseException(status, "Missing X-Alda-Version header. " +
                                                     "Probably not an Alda server.");
+          } else if (status == 409) {
+            // We can't actually throw an UnsavedChangesException here because
+            // the overridden method does not throw UnsavedChangesException.
+            //
+            // (I hate this.)
+            String body = responseBody != null ? responseBody : "";
+            return "UnsavedChangesException:" + body;
           } else if (status < 200 || status > 299) {
             throw new HttpResponseException(status, responseBody);
           } else {
@@ -157,58 +165,117 @@ public class AldaServer {
       };
 
       String responseBody = httpclient.execute(httpRequest, responseHandler);
+      // (I still hate this.)
+      if (responseBody.startsWith("UnsavedChangesException:")) {
+        int colon = responseBody.indexOf(":");
+        throw new UnsavedChangesException(responseBody.substring(colon + 1));
+      }
       return responseBody;
     } finally {
       httpclient.close();
     }
   }
 
-  private String getRequest(String endpoint) throws IOException {
+  private String getRequest(String endpoint)
+    throws IOException, UnsavedChangesException {
+    return getRequest(endpoint, false);
+  }
+
+  private String getRequest(String endpoint, boolean confirming)
+    throws IOException, UnsavedChangesException {
     HttpGet httpget = new HttpGet(host + ":" + port + endpoint);
+    if (confirming) {
+      httpget.addHeader("X-Alda-Confirm", "yes");
+    }
     return doRequest(httpget);
   }
 
-  private String deleteRequest(String endpoint) throws IOException {
+  private String deleteRequest(String endpoint)
+    throws IOException, UnsavedChangesException {
+    return deleteRequest(endpoint, false);
+  }
+
+  private String deleteRequest(String endpoint, boolean confirming)
+    throws IOException, UnsavedChangesException {
     HttpDelete httpdelete = new HttpDelete(host + ":" + port + endpoint);
+    if (confirming) {
+      httpdelete.addHeader("X-Alda-Confirm", "yes");
+    }
     return doRequest(httpdelete);
   }
 
   private String postRequest(String endpoint, HttpEntity entity)
-    throws IOException {
+  throws IOException, UnsavedChangesException {
+    return postRequest(endpoint, entity, false);
+  }
+
+  private String postRequest(String endpoint, HttpEntity entity, boolean confirming)
+    throws IOException, UnsavedChangesException {
     HttpPost httppost = new HttpPost(host + ":" + port + endpoint);
     httppost.setEntity(entity);
+    if (confirming) {
+      httppost.addHeader("X-Alda-Confirm", "yes");
+    }
     return doRequest(httppost);
   }
 
   private String postString(String endpoint, String payload)
-    throws IOException {
+    throws IOException, UnsavedChangesException {
+    return postString(endpoint, payload, false);
+  }
+
+  private String postString(String endpoint, String payload, boolean confirming)
+    throws IOException, UnsavedChangesException {
     StringEntity entity = new StringEntity(payload);
-    return postRequest(endpoint, entity);
+    return postRequest(endpoint, entity, confirming);
   }
 
   private String postFile(String endpoint, File payload)
-    throws IOException {
+    throws IOException, UnsavedChangesException {
+    return postFile(endpoint, payload, false);
+  }
+
+  private String postFile(String endpoint, File payload, boolean confirming)
+    throws IOException, UnsavedChangesException {
     FileEntity entity = new FileEntity(payload);
-    return postRequest(endpoint, entity);
+    return postRequest(endpoint, entity, confirming);
   }
 
   private String putRequest(String endpoint, HttpEntity entity)
-    throws IOException {
+    throws IOException, UnsavedChangesException {
+    return putRequest(endpoint, entity, false);
+  }
+
+  private String putRequest(String endpoint, HttpEntity entity, boolean confirming)
+    throws IOException, UnsavedChangesException {
     HttpPut httpput = new HttpPut(host + ":" + port + endpoint);
     httpput.setEntity(entity);
+    if (confirming) {
+      httpput.addHeader("X-Alda-Confirm", "yes");
+    }
     return doRequest(httpput);
   }
 
   private String putString(String endpoint, String payload)
-    throws IOException {
+    throws IOException, UnsavedChangesException {
+    return putString(endpoint, payload, false);
+  }
+
+  private String putString(String endpoint, String payload, boolean confirming)
+    throws IOException, UnsavedChangesException {
     StringEntity entity = new StringEntity(payload);
-    return putRequest(endpoint, entity);
+    return putRequest(endpoint, entity, confirming);
   }
 
   private String putFile(String endpoint, File payload)
-    throws IOException {
+    throws IOException, UnsavedChangesException {
+    return putFile(endpoint, payload, false);
+  }
+
+  private String putFile(String endpoint, File payload, boolean confirming)
+    throws IOException, UnsavedChangesException {
     FileEntity entity = new FileEntity(payload);
-    return putRequest(endpoint, entity);
+    return putRequest(endpoint, entity, confirming);
   }
 
   private boolean checkForConnection() throws Exception {
@@ -332,7 +399,7 @@ public class AldaServer {
     Util.callClojureFn("alda.repl/start-repl!", args);
   }
 
-  public void stop() throws Exception {
+  public void stop(boolean autoConfirm) throws Exception {
     boolean serverAlreadyDown = !checkForConnection();
     if (serverAlreadyDown) {
       msg("Server already down.");
@@ -340,7 +407,22 @@ public class AldaServer {
     }
 
     msg("Stopping Alda server...");
-    getRequest("/stop");
+    try {
+      getRequest("/stop");
+    } catch (UnsavedChangesException e) {
+      System.out.println();
+      boolean confirm =
+        Util.promptForConfirmation("The score has unsaved changes that will be " +
+                                   "lost.\nAre you sure you want to stop the " +
+                                   "server?", autoConfirm);
+      if (confirm) {
+        System.out.println();
+        msg("Stopping Alda server...");
+        getRequest("/stop", true);
+      } else {
+        return;
+      }
+    }
 
     boolean serverIsDown = waitForLackOfConnection();
     if (serverIsDown) {
@@ -350,8 +432,8 @@ public class AldaServer {
     }
   }
 
-  public void restart() throws Exception {
-    stop();
+  public void restart(boolean autoConfirm) throws Exception {
+    stop(autoConfirm);
     System.out.println();
     startBg();
   }
@@ -410,9 +492,24 @@ public class AldaServer {
     System.out.println(getRequest("/score/" + mode));
   }
 
-  public void delete() throws Exception {
+  public void delete(boolean autoConfirm) throws Exception {
     assertServerUp();
-    deleteRequest("/score");
+
+    try {
+      deleteRequest("/score");
+    } catch (UnsavedChangesException e) {
+      System.out.println();
+      boolean confirm =
+        Util.promptForConfirmation("The score has unsaved changes that will " +
+                                   "be lost.\nAre you sure you want to start a " +
+                                   "new score?", autoConfirm);
+      if (confirm) {
+        deleteRequest("/score", true);
+      } else {
+        return;
+      }
+    }
+
     msg("New score initialized.");
   }
 
@@ -422,28 +519,95 @@ public class AldaServer {
     msg("Playing score...");
   }
 
-  public void play(String code, boolean replaceScore) throws Exception {
+  public void play(String code, boolean replaceScore, boolean autoConfirm) throws Exception {
     startServerIfNeeded();
-    String result = replaceScore ? putString("/play", code)
-                                 : postString("/play", code);
+
+    if (replaceScore) {
+      try {
+        putString("/play", code);
+      } catch (UnsavedChangesException e) {
+        System.out.println();
+        boolean confirm =
+          Util.promptForConfirmation("The current score has unsaved changes " +
+                                     "that will be lost.\nAre you sure you " +
+                                     "want to proceed?", autoConfirm);
+        if (confirm) {
+          putString("/play", code, true);
+        } else {
+          return;
+        }
+      }
+    } else {
+      postString("/play", code);
+    }
+
     msg("Playing code...");
   }
 
-  public void play(File file, boolean replaceScore) throws Exception {
+  public void play(File file, boolean replaceScore, boolean autoConfirm) throws Exception {
     startServerIfNeeded();
-    String result = replaceScore ? putFile("/play", file)
-                                 : postFile("/play", file);
+
+    if (replaceScore) {
+      try {
+        putFile("/play", file);
+      } catch (UnsavedChangesException e) {
+        System.out.println();
+        boolean confirm =
+          Util.promptForConfirmation("The current score has unsaved changes " +
+                                     "that will be lost.\nAre you sure you " +
+                                     "want to proceed?", autoConfirm);
+        if (confirm) {
+          putFile("/play", file, true);
+        } else {
+          return;
+        }
+      }
+    } else {
+      postFile("/play", file);
+    }
+
     msg("Playing file...");
   }
 
-  public void parse(String code, String mode) throws Exception {
+  public void parse(String code, String mode, boolean autoConfirm) throws Exception {
     startServerIfNeeded();
-    System.out.println(postString("/parse/" + mode, code));
+
+    try {
+      String result = postString("/parse/" + mode, code);
+      System.out.println(result);
+    } catch (UnsavedChangesException e) {
+      System.out.println();
+      boolean confirm =
+        Util.promptForConfirmation("The current score has unsaved changes " +
+                                   "that will be lost.\nAre you sure you " +
+                                   "want to proceed?", autoConfirm);
+      if (confirm) {
+        String result = postString("/parse/" + mode, code, true);
+        System.out.println(result);
+      } else {
+        return;
+      }
+    }
   }
 
-  public void parse(File file, String mode) throws Exception {
+  public void parse(File file, String mode, boolean autoConfirm) throws Exception {
     startServerIfNeeded();
-    System.out.println(postFile("/parse/" + mode, file));
+    try {
+      String result = postFile("/parse/" + mode, file);
+      System.out.println(result);
+    } catch (UnsavedChangesException e) {
+      System.out.println();
+      boolean confirm =
+        Util.promptForConfirmation("The current score has unsaved changes " +
+                                   "that will be lost.\nAre you sure you " +
+                                   "want to proceed?", autoConfirm);
+      if (confirm) {
+        String result = postFile("/parse/" + mode, file, true);
+        System.out.println(result);
+      } else {
+        return;
+      }
+    }
   }
 
   public void append(String code) throws Exception {

--- a/client/src/alda/Client.java
+++ b/client/src/alda/Client.java
@@ -59,10 +59,20 @@ public class Client {
   private static class CommandStart {}
 
   @Parameters(commandDescription = "Stop the Alda server")
-  private static class CommandStop {}
+  private static class CommandStop {
+    @Parameter (names = {"-y", "--yes"},
+                description = "Auto-respond 'y' to confirm discarding " +
+                              "unsaved changes")
+    public boolean autoConfirm = false;
+  }
 
   @Parameters(commandDescription = "Restart the Alda server")
-  private static class CommandRestart {}
+  private static class CommandRestart {
+    @Parameter (names = {"-y", "--yes"},
+                description = "Auto-respond 'y' to confirm discarding " +
+                              "unsaved changes")
+    public boolean autoConfirm = false;
+  }
 
   @Parameters(commandDescription = "Display whether the server is up")
   private static class CommandStatus {}
@@ -96,6 +106,10 @@ public class Client {
     @Parameter(names = {"-r", "--replace"},
                description = "Replace the existing score with new code")
     public boolean replaceScore = false;
+
+    @Parameter (names = {"-y", "--yes"},
+                description = "Auto-respond 'y' to confirm e.g. score replacement")
+    public boolean autoConfirm = false;
   }
 
   @Parameters(commandDescription = "Display the result of parsing Alda code")
@@ -117,6 +131,10 @@ public class Client {
     @Parameter(names = {"-m", "--map"},
                description = "Display the map of score data")
     public boolean showScoreMap = false;
+
+    @Parameter (names = {"-y", "--yes"},
+                description = "Auto-respond 'y' to confirm e.g. score replacement")
+    public boolean autoConfirm = false;
   }
 
   @Parameters(commandDescription = "Evaluate Alda code and append it to the " +
@@ -149,7 +167,12 @@ public class Client {
   }
 
   @Parameters(commandDescription = "Delete the score and start a new one")
-  private static class CommandNew {}
+  private static class CommandNew {
+    @Parameter (names = {"-y", "--yes"},
+                description = "Auto-respond 'y' to confirm discarding " +
+                              "unsaved changes")
+    public boolean autoConfirm = false;
+  }
 
   @Parameters(commandDescription = "Edit the score in progress",
               hidden = true)
@@ -250,11 +273,11 @@ public class Client {
           break;
         case "stop":
         case "down":
-          server.stop();
+          server.stop(stop.autoConfirm);
           break;
         case "restart":
         case "downup":
-          server.restart();
+          server.restart(restart.autoConfirm);
           break;
 
         case "status":
@@ -275,13 +298,13 @@ public class Client {
               server.play();
               break;
             case "file":
-              server.play(play.file, play.replaceScore);
+              server.play(play.file, play.replaceScore, play.autoConfirm);
               break;
             case "code":
-              server.play(play.code, play.replaceScore);
+              server.play(play.code, play.replaceScore, play.autoConfirm);
               break;
             case "stdin":
-              server.play(Util.getStdIn(), play.replaceScore);
+              server.play(Util.getStdIn(), play.replaceScore, play.autoConfirm);
               break;
           }
           break;
@@ -292,13 +315,13 @@ public class Client {
 
           switch (inputType) {
             case "file":
-              server.parse(parse.file, mode);
+              server.parse(parse.file, mode, parse.autoConfirm);
               break;
             case "code":
-              server.parse(parse.code, mode);
+              server.parse(parse.code, mode, parse.autoConfirm);
               break;
             case "stdin":
-              server.parse(Util.getStdIn(), mode);
+              server.parse(Util.getStdIn(), mode, parse.autoConfirm);
               break;
             default:
               throw new Exception("Please provide some Alda code in the form " +
@@ -335,7 +358,7 @@ public class Client {
 
         case "new":
         case "delete":
-          server.delete();
+          server.delete(newScore.autoConfirm);
           break;
 
         case "edit":

--- a/client/src/alda/UnsavedChangesException.java
+++ b/client/src/alda/UnsavedChangesException.java
@@ -1,0 +1,9 @@
+package alda;
+
+public class UnsavedChangesException extends Exception {
+
+  public UnsavedChangesException(String msg) {
+    super(msg);
+  }
+
+}

--- a/client/src/alda/Util.java
+++ b/client/src/alda/Util.java
@@ -1,5 +1,6 @@
 package alda;
 
+import java.io.Console;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -25,6 +26,35 @@ public final class Util {
 
   public static Object[] conj(Object[] a, Object b) {
     return concat(a, new Object[]{b});
+  }
+
+  public static boolean promptForConfirmation(String prompt, boolean autoConfirm) {
+    if (autoConfirm) {
+      System.out.println(prompt + "\n");
+      System.out.println("(-y/--yes flag set. Responding yes on your behalf.)");
+      return true;
+    }
+
+    Console console = System.console();
+    if (System.console() != null) {
+      Boolean confirm = null;
+      while (confirm == null) {
+        String response = console.readLine(prompt + " (y/n) ");
+        if (response.toLowerCase().startsWith("y")) {
+          confirm = true;
+        } else if (response.toLowerCase().startsWith("n")) {
+          confirm = false;
+        }
+      }
+      return confirm.booleanValue();
+    } else {
+      System.out.println(prompt + "\n");
+      System.out.println("Unable to get a response because you are " +
+                         "redirecting input.\nI'm just gonna assume the " +
+                         "answer is no.\n\n" +
+                         "To auto-respond yes, use the -y/--yes option.");
+      return false;
+    }
   }
 
   public static String inputType(File file, String code)

--- a/server/src/alda/server.clj
+++ b/server/src/alda/server.clj
@@ -39,11 +39,18 @@
 
 (def filename (atom nil))
 
+(defn modified?
+  []
+  (if @filename
+    "TODO"
+    (not (empty? *score-text*))))
+
 (defn score-info
   []
   {:status      "up"
    :version     -version-
    :filename    @filename
+   :modified?   (modified?)
    :line-count  (count (str/split *score-text* #"[\n\r]+"))
    :char-count  (count *score-text*)
    :instruments (for [[k v] (:instruments (score-map))]

--- a/server/src/alda/server.clj
+++ b/server/src/alda/server.clj
@@ -198,6 +198,13 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn wrap-print-request
+  "For debug purposes."
+  [next-handler]
+  (fn [request]
+    (prn request)
+    (next-handler request)))
+
 (defn wrap-play-opts
   [next-handler play-opts]
   (fn [request]
@@ -208,7 +215,8 @@
   [& {:keys [play-opts]}]
   (-> (wrap-defaults server-routes api-defaults)
       (wrap-multipart-params)
-      (wrap-play-opts (or play-opts *play-opts*))))
+      (wrap-play-opts (or play-opts *play-opts*))
+      #_(wrap-print-request)))
 
 (defn start-server!
   [port & {:keys [pre-buffer post-buffer]}]

--- a/server/src/alda/server.clj
+++ b/server/src/alda/server.clj
@@ -45,6 +45,11 @@
     "TODO"
     (not (empty? *score-text*))))
 
+(defn confirming?
+  [{:keys [headers] :as request}]
+  (let [confirm-header (get headers "x-alda-confirm" "false")]
+    (not (contains? #{"" "no" "false"} (.toLowerCase confirm-header)))))
+
 (defn score-info
   []
   {:status      "up"
@@ -70,6 +75,12 @@
 (def ^:private success      (response 200))
 (def ^:private user-error   (response 400))
 (def ^:private server-error (response 500))
+
+(def unsaved-changes-response
+  ((response 409) (str "Warning: the score has unsaved changes. Are you sure "
+                       "you want to do this?\n\n"
+                       "If so, please re-submit your request and include the "
+                       "header X-Alda-Confirm:yes.")))
 
 (defn- edn-response
   [x]
@@ -112,9 +123,12 @@
 (defn stop-server!
   []
   (log/info "Received request to stop. Shutting down...")
-  (future
-    (Thread/sleep 300)
-    (System/exit 0))
+  (try
+    (future
+      (Thread/sleep 300)
+      (System/exit 0))
+    (catch Throwable e
+      (server-error (str "ERROR: " (.getMessage e)))))
   (success "Shutting down."))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -133,9 +147,6 @@
   (DELETE "/" []
     (stop-server!))
 
-  ; TODO: make the /parse/map endpoint not overwrite the current score
-  ; (will require refactoring alda.lisp to not use top-level vars)
-
   ; parse code and return the resulting alda.lisp code
   (POST "/parse" {:keys [params body] :as request}
     (let [code (get-input params body)]
@@ -144,10 +155,15 @@
     (let [code (get-input params body)]
       (handle-code-parse code :mode :lisp)))
 
+  ; TODO: make the /parse/map endpoint not overwrite the current score
+  ; (will require refactoring alda.lisp to not use top-level vars)
+
   ; parse + evaluate code and return the resulting score map
   (POST "/parse/map" {:keys [params body] :as request}
     (let [code (get-input params body)]
-      (handle-code-parse code :mode :map)))
+      (if (and (modified?) (not (confirming? request)))
+        unsaved-changes-response
+        (handle-code-parse code :mode :map))))
 
   ; play the full score (default), or from `from` to `to` params
   (GET "/play" {:keys [play-opts params] :as request}
@@ -165,10 +181,12 @@
 
   ; overwrite the current score and play it
   (PUT "/play" {:keys [play-opts params body] :as request}
-    (let [code (get-input params body)]
-      (score*)
-      (binding [*play-opts* play-opts]
-        (handle-code code))))
+    (if (and (modified?) (not (confirming? request)))
+      unsaved-changes-response
+      (let [code (get-input params body)]
+        (score*)
+        (binding [*play-opts* play-opts]
+          (handle-code code)))))
 
   ; add to the current score without playing anything
   (POST "/add" {:keys [params body] :as request}
@@ -190,18 +208,23 @@
     (edn-response (score-map)))
 
   ; delete the current score and start a new one
-  (DELETE "/score" []
-    (score*)
-    (success "New score initialized."))
+  (DELETE "/score" {:as request}
+    (if (and (modified?) (not (confirming? request)))
+      unsaved-changes-response
+      (do
+        (score*)
+        (success "New score initialized."))))
 
   ; stop the server (alias for DELETE "/")
-  (GET "/stop" []
-    (stop-server!))
+  (GET "/stop" {:as request}
+    (if (and (modified?) (not (confirming? request)))
+      unsaved-changes-response
+      (stop-server!)))
 
   (GET "/version" []
     (success (str "alda v" -version-)))
 
-  (not-found "Invalid route."))
+  (not-found (user-error "Invalid route.")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/server/src/alda/util.clj
+++ b/server/src/alda/util.clj
@@ -85,10 +85,12 @@
     (apply <= x (conj (vec xs) (+ x 0.01)))))
 
 (defn set-timbre-level!
-  []
-  (timbre/set-level! (if-let [level (System/getenv "TIMBRE_LEVEL")]
-                       (keyword (str/replace level #":" ""))
-                       :warn)))
+  ([]
+    (timbre/set-level! (if-let [level (System/getenv "TIMBRE_LEVEL")]
+                         (keyword (str/replace level #":" ""))
+                         :warn)))
+  ([level]
+    (timbre/set-level! level)))
 
 (defn check-for
   "Checks to see if a given file already exists. If it does, prompts the user


### PR DESCRIPTION
Closes #152.

- By default, the server will return 409 if it receives any request asking it to discard unsaved changes.
- For now, "unsaved changes" is naïvely defined as the score being non-empty. (Will implement the file-checking behavior (i.e. if the score was loaded from (or saved to) a file, is the score in memory any different from what's in the file?) very soon along with the `alda save` and `alda load` commands.)
- Re-submitting the request with the `X-Alda-Confirm` header set to anything except for "", "no" or "false" will force the action to take place.
- When the client gets a 409, it warns the user that this action will result in unsaved changes being lost, and prompts for confirmation.
- Also added `-y`/`--yes` options for each relevant command. When this flag is included, the client will confirm automatically when confronted with such a situation.