### PR TITLE
`alda save` command

### DIFF
--- a/client/src/alda/AldaServer.java
+++ b/client/src/alda/AldaServer.java
@@ -543,6 +543,13 @@ public class AldaServer {
     msg("Loaded file.");
   }
 
+  public void loadWithoutAsking(File file) throws Exception {
+    startServerIfNeeded();
+    putFile("/load", file, true);
+    putString("/filename", file.getAbsolutePath());
+    msg("Loaded file.");
+  }
+
   public void load(String code, boolean autoConfirm) throws Exception {
     startServerIfNeeded();
 
@@ -562,6 +569,38 @@ public class AldaServer {
     }
 
     msg("Loaded code.");
+  }
+
+  public void save() throws Exception {
+    assertServerUp();
+    getRequest("/save");
+    msg("File saved.");
+  }
+
+  public void save(File file, boolean autoConfirm) throws Exception {
+    assertServerUp();
+
+    String filename = file.getAbsolutePath();
+
+    try {
+      putString("/save", filename);
+      msg("File saved.");
+    } catch (UnsavedChangesException e) {
+      System.out.println();
+      boolean confirm =
+        Util.promptForConfirmation("There is an existing file with the " +
+                                   "filename you specified. Saving the score " +
+                                   "to this file will erase whatever is " +
+                                   "already there.\n\n" +
+                                   "Are you sure you want to do this?",
+                                   autoConfirm);
+      if (confirm) {
+        putString("/save", filename, true);
+        msg("File saved.");
+      } else {
+        return;
+      }
+    }
   }
 
   public void play() throws Exception {

--- a/client/src/alda/AldaServer.java
+++ b/client/src/alda/AldaServer.java
@@ -574,7 +574,7 @@ public class AldaServer {
   public void save() throws Exception {
     assertServerUp();
     getRequest("/save");
-    msg("File saved.");
+    msg("File saved: " + getInfo().filename);
   }
 
   public void save(File file, boolean autoConfirm) throws Exception {
@@ -584,7 +584,7 @@ public class AldaServer {
 
     try {
       putString("/save", filename);
-      msg("File saved.");
+      msg("File saved: " + filename);
     } catch (UnsavedChangesException e) {
       System.out.println();
       boolean confirm =
@@ -596,7 +596,7 @@ public class AldaServer {
                                    autoConfirm);
       if (confirm) {
         putString("/save", filename, true);
-        msg("File saved.");
+        msg("File saved: " + filename);
       } else {
         return;
       }

--- a/client/src/alda/Client.java
+++ b/client/src/alda/Client.java
@@ -168,6 +168,11 @@ public class Client {
 
   @Parameters(commandDescription = "Delete the score and start a new one")
   private static class CommandNew {
+    @Parameter (names = {"-f", "--file"},
+                description = "A filename for the new score",
+                converter = FileConverter.class)
+    public File file;
+
     @Parameter (names = {"-y", "--yes"},
                 description = "Auto-respond 'y' to confirm discarding " +
                               "unsaved changes")
@@ -392,6 +397,9 @@ public class Client {
         case "new":
         case "delete":
           server.delete(newScore.autoConfirm);
+          if (newScore.file != null) {
+            server.save(newScore.file, newScore.autoConfirm);
+          }
           break;
 
         case "load":

--- a/client/src/alda/Client.java
+++ b/client/src/alda/Client.java
@@ -191,7 +191,20 @@ public class Client {
     public boolean autoConfirm = false;
   }
 
-  @Parameters(commandDescription = "Edit the score in progress")
+  @Parameters(commandDescription = "Save the score to a file")
+  private static class CommandSave {
+    @Parameter(names = {"-f", "--file"},
+               description = "The path to a file to which to save the score",
+               converter = FileConverter.class)
+    public File file;
+
+    @Parameter (names = {"-y", "--yes"},
+                description = "Auto-respond 'y' to confirm overwriting an " +
+                              "existing file")
+    public boolean autoConfirm = false;
+  }
+
+  @Parameters(commandDescription = "Edit the score")
   private static class CommandEdit {
     @Parameter(names = {"-e", "--editor"},
                description = "pass the file to a custom command instead of " +
@@ -217,6 +230,7 @@ public class Client {
     CommandScore   score     = new CommandScore();
     CommandNew     newScore  = new CommandNew();
     CommandLoad    load      = new CommandLoad();
+    CommandSave    save      = new CommandSave();
     CommandEdit    edit      = new CommandEdit();
 
     JCommander jc = new JCommander(globalOpts);
@@ -242,6 +256,7 @@ public class Client {
     jc.addCommand("score", score);
     jc.addCommand("new", newScore, "delete");
     jc.addCommand("load", load, "open");
+    jc.addCommand("save", save);
     jc.addCommand("edit", edit);
 
     try {
@@ -399,6 +414,24 @@ public class Client {
           }
           break;
 
+        case "save":
+          inputType = Util.inputType(save.file, null);
+
+          switch (inputType) {
+            // "score" is returned when no filename is supplied
+            case "score":
+              server.save();
+              break;
+            case "file":
+              server.save(save.file, save.autoConfirm);
+              break;
+            case "stdin":
+              File file = new File(Util.getStdIn().trim());
+              server.save(file, save.autoConfirm);
+              break;
+          }
+          break;
+
         case "edit":
           String editor = System.getenv("EDITOR");
           if (edit.editor != null) {
@@ -410,23 +443,26 @@ public class Client {
 
           AldaServerInfo scoreInfo = server.getInfo();
 
+          if (scoreInfo.filename == null) {
+            server.msg("Score has not been saved yet. There is no file to " +
+                       "edit.");
+            break;
+          }
+
+          File file = new File(scoreInfo.filename);
+
           if (scoreInfo.isModified) {
             boolean saveFirst = Util.promptForConfirmation(
               "Your score has unsaved changes that will be lost unless you " +
               "save first.\nWould you like to save before editing?", false);
 
             if (saveFirst) {
-              System.out.println("TODO: save");
+              server.save();
             }
           }
 
-          if (scoreInfo.filename == null) {
-            server.msg("Score has not been saved yet. There is no file to " +
-                       "edit.");
-          } else {
-            Util.runProgramInFg(editor, scoreInfo.filename);
-            System.out.println("TODO: save edited file");
-          }
+          Util.runProgramInFg(editor, scoreInfo.filename);
+          server.loadWithoutAsking(file);
           break;
       }
     } catch (Exception e) {

--- a/server/src/alda/server.clj
+++ b/server/src/alda/server.clj
@@ -242,19 +242,18 @@
     (if @score-filename
       (do
         (spit @score-filename *score-text*)
-        (success "File saved."))
+        (success (str "File saved: " @score-filename)))
       (user-error "You must supply a filename.")))
 
   ; save changes to a file
   (PUT "/save" {:keys [params body] :as request}
     (let [filename (str/trim (get-input params body))]
-      (prn :filename filename :exists? (.exists (io/as-file filename)))
       (if (and (.exists (io/as-file filename)) (not (confirming? request)))
         existing-file-response
         (do
           (spit filename *score-text*)
           (reset! score-filename filename)
-          (success "File saved.")))))
+          (success (str "File saved: " @score-filename))))))
 
   ; get the current score text
   (GET "/score" []


### PR DESCRIPTION
Closes #156.

Foregoing the Alda REPL `:save` command for the time being, as it depends on #154.