### PR TITLE
Build uberjar with JDK 1.7 support

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -54,6 +54,10 @@
       version)))
 
 (task-options!
+  javac   {:options ["-source" "1.7"
+                     "-target" "1.7"
+                     "-bootclasspath" (System/getenv "JDK7_BOOTCLASSPATH")]}
+
   pom     {:project 'alda
            :version alda.version/-version-
            :description "A music programming language for musicians"
@@ -103,6 +107,21 @@
                           alda.parser.examples-test
                           }})
 
+(deftask assert-jdk7-bootclasspath
+  "Ensures that the JDK7_BOOTCLASSPATH environment variable is set, as required
+   to build the uberjar with JDK7 support."
+  []
+  (with-pre-wrap fileset
+    (assert (not (empty? (System/getenv "JDK7_BOOTCLASSPATH")))
+            (str "Alda requires JDK7 in order to build its uberjar, in order "
+                 "to provide out-of-the-box support for users who may have "
+                 "older versions of Java. Please install JDK7 and set the "
+                 "environment variable JDK7_BOOTCLASSPATH to the path to your "
+                 "JDK7 classpath jar, e.g. (OS X example) "
+                 "/Library/Java/JavaVirtualMachines/jdk1.7.0_71.jdk/Contents/"
+                 "Home/jre/lib/rt.jar"))
+    fileset))
+
 (deftask dev
   "Runs the Alda server for development.
 
@@ -133,7 +152,11 @@
 (deftask package
   "Builds an uberjar."
   []
-  (comp (javac) (pom) (uber) (jar)))
+  (comp (assert-jdk7-bootclasspath)
+        (javac)
+        (pom)
+        (uber)
+        (jar)))
 
 (deftask build
   "Builds an uberjar and executable binaries for Unix/Linux and Windows."


### PR DESCRIPTION
Closes #171 

`boot build` will now build uberjars (and therefore binaries) that are compatible with JDK 1.7+, making it so that people with older Java versions can use Alda.

I tried going back to JDK 1.6, but there are a couple incompatible things in the Java client source that would need to be resolved, and I'm not sure if it's worth the effort at this point, with JDK 1.6 on its way out. We can always revisit in the future if there is a need for Java 6 compatibility.

Blockers for Java 6 compatibility:

1) The switch statement in Client.java operates on strings, which is not supported in Java 6. We could just make it a series of if/else if statements.

2) The use of `.inheritIO()` in Util.java here:

     public static void runProgramInFg(String... args)
     throws IOException, InterruptedException {
       new ProcessBuilder(args).inheritIO().start().waitFor();
     }

   I'm sure there is some pre-JDK7 workaround for this.