### PR TITLE
bugfix re: voice parsing

### DIFF
--- a/server/grammar/events.bnf
+++ b/server/grammar/events.bnf
@@ -1,40 +1,42 @@
-<part>          = <ows> events <ows>
-<events>        = event? (<ows> event)*
+<part>                = <ows> events <ows>
+<events>              = event? (<ows> event)*
+<events-inside-voice> = event-inside-voice? (<ows> event-inside-voice)*
 
     (* notes, chords & other events *)
 
-<event>         = single-event | repeat | voices
-<single-event>  = chord | note | rest | octave-change |
+<event>               = single-event | repeat | voices
+<event-inside-voice>  = single-event | repeat
+<single-event>        = chord | note | rest | octave-change |
                   clj-expr-cached | marker | at-marker | barline |
                   event-sequence | cram
 
-repeat          = single-event <ows> <"*"> <ows> positive-number <ows>
+repeat                = single-event <ows> <"*"> <ows> positive-number <ows>
 
     (* chords, notes, rests *)
 
-chord           = (note | rest) subchord+
-<subchord>      = <"/"> <ows> (octave-change | clj-expr-cached)*
+chord                 = (note | rest) subchord+
+<subchord>            = <"/"> <ows> (octave-change | clj-expr-cached)*
                         <ows> (note | rest) <ows>
-note            = pitch duration? <ows> slur?
-rest            = <"r"> duration? <ows>
+note                  = pitch duration? <ows> slur?
+rest                  = <"r"> duration? <ows>
 
     (* pitch *)
 
-pitch           = #"[a-g]" accidental*
-<accidental>    = flat | sharp | natural
-flat            = "-"
-sharp           = "+"
-natural         = "="
+pitch                 = #"[a-g]" accidental*
+<accidental>          = flat | sharp | natural
+flat                  = "-"
+sharp                 = "+"
+natural               = "="
 
     (* octaves *)
 
-<octave-change> = (octave-set | octave-up | octave-down) <ows>
-octave-set      = <"o"> number
-octave-up       = <">">
-octave-down     = <"<">
+<octave-change>       = (octave-set | octave-up | octave-down) <ows>
+octave-set            = <"o"> number
+octave-up             = <">">
+octave-down           = <"<">
 
     (* markers *)
 
-marker          = <"%"> name <ows>
-at-marker       = <"@"> name <ows>
+marker                = <"%"> name <ows>
+at-marker             = <"@"> name <ows>
 

--- a/server/grammar/voices.bnf
+++ b/server/grammar/voices.bnf
@@ -1,5 +1,5 @@
 voices       = voice+ (<voice-zero> | <#"\z">)
-voice        = voice-number <ows> events
+voice        = voice-number <ows> events-inside-voice
 voice-number = <"V"> #"[1-9]\d*" <":"> <ows>
 <voice-zero> = <"V0:"> <ows>
 

--- a/server/test/alda/parser/events_test.clj
+++ b/server/test/alda/parser/events_test.clj
@@ -39,23 +39,43 @@
 
 (deftest voice-tests
   (testing "voices"
-    (is (= (parse-with-context :music-data "V1: a b c")
-           '((alda.lisp/voices
-               (alda.lisp/voice 1
-                 (alda.lisp/note (alda.lisp/pitch :a))
-                 (alda.lisp/note (alda.lisp/pitch :b))
-                 (alda.lisp/note (alda.lisp/pitch :c)))))))
-    (is (= (parse-with-context :music-data "V1: a b c
-                                            V2: d e f")
-           '((alda.lisp/voices
-               (alda.lisp/voice 1
-                 (alda.lisp/note (alda.lisp/pitch :a))
-                 (alda.lisp/note (alda.lisp/pitch :b))
-                 (alda.lisp/note (alda.lisp/pitch :c)))
-               (alda.lisp/voice 2
-                 (alda.lisp/note (alda.lisp/pitch :d))
-                 (alda.lisp/note (alda.lisp/pitch :e))
-                 (alda.lisp/note (alda.lisp/pitch :f)))))))))
+    (is (= (parse-with-context :part "piano: V1: a b c")
+           '(alda.lisp/part {:names ["piano"]}
+              (alda.lisp/voices
+                (alda.lisp/voice 1
+                  (alda.lisp/note (alda.lisp/pitch :a))
+                  (alda.lisp/note (alda.lisp/pitch :b))
+                  (alda.lisp/note (alda.lisp/pitch :c)))))))
+    (is (= (parse-with-context :part "piano:
+                                        V1: a b c
+                                        V2: d e f")
+           '(alda.lisp/part {:names ["piano"]}
+              (alda.lisp/voices
+                (alda.lisp/voice 1
+                  (alda.lisp/note (alda.lisp/pitch :a))
+                  (alda.lisp/note (alda.lisp/pitch :b))
+                  (alda.lisp/note (alda.lisp/pitch :c)))
+                (alda.lisp/voice 2
+                  (alda.lisp/note (alda.lisp/pitch :d))
+                  (alda.lisp/note (alda.lisp/pitch :e))
+                  (alda.lisp/note (alda.lisp/pitch :f)))))))
+    (is (= (parse-with-context :part "piano:
+                                        V1: [a b c] *8
+                                        V2: [d e f] *8")
+           '(alda.lisp/part {:names ["piano"]}
+              (alda.lisp/voices
+                (alda.lisp/voice 1
+                  (alda.lisp/times 8
+                    (do
+                      (alda.lisp/note (alda.lisp/pitch :a))
+                      (alda.lisp/note (alda.lisp/pitch :b))
+                      (alda.lisp/note (alda.lisp/pitch :c)))))
+                (alda.lisp/voice 2
+                  (alda.lisp/times 8
+                    (do
+                      (alda.lisp/note (alda.lisp/pitch :d))
+                      (alda.lisp/note (alda.lisp/pitch :e))
+                      (alda.lisp/note (alda.lisp/pitch :f)))))))))))
 
 (deftest marker-tests
   (testing "markers"


### PR DESCRIPTION
In some cases, voice parsing wasn't happening correctly -- subsequent voices were being nested inside of the previous voice, instead of them all being nested at the same level in the voice group like they should be. This was caused by an ambiguous grammar rule that allowed a voice group to be an event in a voice. Alda doesn't support nesting voices inside of voices, so we can solve the ambiguity by disallowing that explicitly.