### PR TITLE
Updated the Windows installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,15 @@ For more examples, see these [example scores](https://github.com/alda-lang/alda/
 
 * Go to the [latest release](https://github.com/alda-lang/alda/releases/latest) page and download `alda.exe`.
 
-* Make the `alda` command available by moving `alda.exe` to your system root path:
+* Make the file executable:
+  * Go to your downloads folder, right click `alda.exe` to open up its file properties, and click `unblock`
 
-        C:\> move alda.exe %SystemRoot%
+* Copy `alda.exe` to a location that makes sense for you. If you follow standard Windows conversions, this means creating a folder called `Alda` in your `Program Files (x86)` folder, and then moving the `alda.exe` file into it.
+
+* Make `alda` available on your `PATH`:
+  *  Go to the windows `System` control panel option, select `Advanced system settings` and then click on `Environment Variables`, then edit the `PATH` variable (either specifically for your user account or for the system in general) and add `;C:\Program Files (x86)\Alda` to the end. Save this edit. Note that if you places `alda.exe` in a different folder, you will need to use that folder's full path name in your edit.
+
+You will now be able to run Alda from anywhere in the command prompt by typing `alda`, but note that command prompts that were already open will need to be restarted before they will pick up on the new PATH value.
 
 ### Updating Alda
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For more examples, see these [example scores](https://github.com/alda-lang/alda/
 * Copy `alda.exe` to a location that makes sense for you. If you follow standard Windows conversions, this means creating a folder called `Alda` in your `Program Files (x86)` folder, and then moving the `alda.exe` file into it.
 
 * Make `alda` available on your `PATH`:
-  *  Go to the windows `System` control panel option, select `Advanced system settings` and then click on `Environment Variables`, then edit the `PATH` variable (either specifically for your user account or for the system in general) and add `;C:\Program Files (x86)\Alda` to the end. Save this edit. Note that if you places `alda.exe` in a different folder, you will need to use that folder's full path name in your edit.
+  *  Go to the Windows `System` control panel option, select `Advanced System Settings` and then click on `Environment Variables`, then edit the `PATH` variable (either specifically for your user account or for the system in general) and add `;C:\Program Files (x86)\Alda` to the end. Save this edit. Note that if you placed `alda.exe` in a different folder, you will need to use that folder's full path name in your edit, instead.
 
 You will now be able to run Alda from anywhere in the command prompt by typing `alda`, but note that command prompts that were already open will need to be restarted before they will pick up on the new PATH value.
 


### PR DESCRIPTION
fixes #217 

I've updated the README.md with instructions on how to manually "install" the `alda.exe` program following standard Windows conventions, although I am assuming it's a 32 bit, rather than a 64 bit executable. If it's 64 bit then it'll have to go into `Program Files`, not `Program Files (x86)`