### PR TITLE
Misc. dev setup improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,5 +15,5 @@ If you're confused about how some aspect of the code works (Clojure questions, "
 
 ## Development Guide
 
-For a high-level overview of how Alda works, see our [development guide](./doc/development-guide.md).
+For details about testing and building Alda, and a high-level overview of how Alda works, see our [development guide](./doc/development-guide.md).
 

--- a/build.boot
+++ b/build.boot
@@ -110,7 +110,7 @@
                           alda.util-test
 
                           ; benchmarks / smoke tests
-                          alda.parser.examples-test
+                          alda.examples-test
                           }})
 
 (deftask assert-jdk7-bootclasspath

--- a/build.boot
+++ b/build.boot
@@ -7,6 +7,7 @@
                   [adzerk/bootlaces      "0.1.12" :scope "test"]
                   [adzerk/boot-jar2bin   "1.1.0"  :scope "test"]
                   [adzerk/boot-test      "1.0.4"  :scope "test"]
+                  [str-to-argv           "0.1.0"  :score "test"]
 
                   ; server
                   [org.clojure/clojure    "1.8.0"]
@@ -129,11 +130,30 @@
     fileset))
 
 (deftask dev
-  "Runs the Alda server (default) or REPL for development.
+  "Runs the Alda server (default), REPL, or client for development.
 
    *** REPL ***
 
    Simply run `boot dev -a repl` and you're in!
+
+   *** CLIENT ***
+
+   To test changes to the Alda client, run `boot dev -a client -x \"args here\"`.
+
+   For example:
+
+      boot dev -a client -x \"play --file /path/to/file.alda\"
+
+   The arguments must be a single command-line string to be passed to the
+   command-line client as if entering them on the command line. The example
+   above is equivalent to running `alda play --file /path/to/file.alda` on the
+   command line.
+
+   One caveat to running the client this way (as opposed to building it and
+   running the resulting executable) is that the client does not have the
+   necessary permissions to start a new process, e.g. to start an Alda server
+   via the client. If you'd like to test local changes to the server code,
+   you'll need to run the server instead (see SERVER below).
 
    *** SERVER ***
 
@@ -142,7 +162,9 @@
    the Alda client to identify the dev server process as an Alda server and
    include it in the list of running servers.
 
-   * e.g.: boot dev --port 27713 --alda-fingerprint
+   For example:
+
+      boot dev -a server --port 27713 --alda-fingerprint
 
    Take care to include the --port long option as well, so the client knows
    the port on which the dev server is running.
@@ -150,10 +172,12 @@
    There is a middleware that reloads all the server namespaces before each
    request, so that the server does not need to be restarted after making
    changes."
-  [a app              APP  str  "The Alda application to run (server or repl)"
+  [a app              APP  str  "The Alda application to run (server, repl or client)."
+   x args             ARGS str  "The string of CLI args to pass to the client."
    p port             PORT int  "The port on which to start the server."
    F alda-fingerprint      bool "Allow the Alda client to identify this as an Alda server."]
   (comp
+    (if (= app "client") (javac) identity)
     (with-pre-wrap fs
       (let [direct-linking (System/getProperty "clojure.compiler.direct-linking")
             start-server!  (fn []
@@ -163,7 +187,13 @@
                              ((resolve 'alda.server/start-server!) (or port 27713)))
             start-repl!    (fn []
                              (require 'alda.repl)
-                             ((resolve 'alda.repl/start-repl!)))]
+                             ((resolve 'alda.repl/start-repl!)))
+            run-client!    (fn []
+                             (require '[str-to-argv])
+                             (import 'alda.Client)
+                             (eval `(alda.Client/main
+                                      (into-array String
+                                        (str-to-argv/split-args (or ~args ""))))))]
         (when-not (= direct-linking "true")
           (println "WARNING: You should include the JVM option"
                    "-Dclojure.compiler.direct-linking=true, as this option is"
@@ -174,8 +204,9 @@
           nil      (start-server!)
           "server" (start-server!)
           "repl"   (start-repl!)
+          "client" (run-client!)
           (do
-            (println "ERROR: -a/--app must be server or repl")
+            (println "ERROR: -a/--app must be server, repl or client")
             (System/exit 1))))
       fs)
     (wait)))

--- a/client/src/alda/Client.java
+++ b/client/src/alda/Client.java
@@ -127,8 +127,8 @@ public class Client {
                description = "Replace the existing score with new code")
     public boolean replaceScore = false;
 
-    @Parameter (names = {"-y", "--yes"},
-                description = "Auto-respond 'y' to confirm e.g. score replacement")
+    @Parameter(names = {"-y", "--yes"},
+               description = "Auto-respond 'y' to confirm e.g. score replacement")
     public boolean autoConfirm = false;
   }
 
@@ -152,8 +152,8 @@ public class Client {
                description = "Display the map of score data")
     public boolean showScoreMap = false;
 
-    @Parameter (names = {"-y", "--yes"},
-                description = "Auto-respond 'y' to confirm e.g. score replacement")
+    @Parameter(names = {"-y", "--yes"},
+               description = "Auto-respond 'y' to confirm e.g. score replacement")
     public boolean autoConfirm = false;
   }
 
@@ -188,14 +188,14 @@ public class Client {
 
   @Parameters(commandDescription = "Delete the score and start a new one")
   private static class CommandNew extends AldaCommand {
-    @Parameter (names = {"-f", "--file"},
-                description = "A filename for the new score",
-                converter = FileConverter.class)
+    @Parameter(names = {"-f", "--file"},
+               description = "A filename for the new score",
+               converter = FileConverter.class)
     public File file;
 
-    @Parameter (names = {"-y", "--yes"},
-                description = "Auto-respond 'y' to confirm discarding " +
-                              "unsaved changes")
+    @Parameter(names = {"-y", "--yes"},
+               description = "Auto-respond 'y' to confirm discarding " +
+                             "unsaved changes")
     public boolean autoConfirm = false;
   }
 
@@ -210,9 +210,9 @@ public class Client {
                description = "A string of Alda code")
     public String code;
 
-    @Parameter (names = {"-y", "--yes"},
-                description = "Auto-respond 'y' to confirm discarding " +
-                              "unsaved changes")
+    @Parameter(names = {"-y", "--yes"},
+               description = "Auto-respond 'y' to confirm discarding " +
+                             "unsaved changes")
     public boolean autoConfirm = false;
   }
 
@@ -223,9 +223,9 @@ public class Client {
                converter = FileConverter.class)
     public File file;
 
-    @Parameter (names = {"-y", "--yes"},
-                description = "Auto-respond 'y' to confirm overwriting an " +
-                              "existing file")
+    @Parameter(names = {"-y", "--yes"},
+               description = "Auto-respond 'y' to confirm overwriting an " +
+                             "existing file")
     public boolean autoConfirm = false;
   }
 
@@ -326,12 +326,12 @@ public class Client {
       switch (command) {
         case "help":
           jc.usage();
-          break;
+          System.exit(0);
 
         case "update":
           handleCommandSpecificHelp(jc, "update", update);
           Util.updateAlda();
-          break;
+          System.exit(0);
 
         case "server":
           handleCommandSpecificHelp(jc, "server", serverCmd);
@@ -348,36 +348,43 @@ public class Client {
         case "init":
           handleCommandSpecificHelp(jc, "start", start);
           server.startBg();
-          break;
+          System.exit(0);
+
         case "stop":
         case "down":
           handleCommandSpecificHelp(jc, "stop", stop);
           server.stop(stop.autoConfirm);
-          break;
+          System.exit(0);
+
         case "restart":
         case "downup":
           handleCommandSpecificHelp(jc, "restart", restart);
           server.restart(restart.autoConfirm);
-          break;
+          System.exit(0);
+
         case "list":
           handleCommandSpecificHelp(jc, "list", list);
           Util.listServers();
-          break;
+          System.exit(0);
+
         case "status":
           handleCommandSpecificHelp(jc, "status", status);
           server.status();
-          break;
+          System.exit(0);
+
         case "version":
           handleCommandSpecificHelp(jc, "version", version);
           System.out.println("Client version: " + Util.version());
           System.out.println();
           System.out.println("Server version:");
           server.version();
-          break;
+          System.exit(0);
+
         case "info":
           handleCommandSpecificHelp(jc, "info", info);
           server.info();
-          break;
+          System.exit(0);
+
         case "play":
           handleCommandSpecificHelp(jc, "play", play);
           inputType = Util.inputType(play.file, play.code);
@@ -396,7 +403,7 @@ public class Client {
               server.play(Util.getStdIn(), play.replaceScore, play.autoConfirm);
               break;
           }
-          break;
+          System.exit(0);
 
         case "parse":
           handleCommandSpecificHelp(jc, "parse", parse);
@@ -417,7 +424,7 @@ public class Client {
               throw new Exception("Please provide some Alda code in the form " +
                                   "of a string, file, or STDIN.");
           }
-          break;
+          System.exit(0);
 
         case "append":
         case "add":
@@ -438,7 +445,7 @@ public class Client {
               throw new Exception("Please provide some Alda code in the form " +
                                   "of a string, file, or STDIN.");
           }
-          break;
+          System.exit(0);
 
         case "score":
           if(score.help) {
@@ -449,7 +456,7 @@ public class Client {
                                 score.showLispCode,
                                 score.showScoreMap);
           server.score(mode);
-          break;
+          System.exit(0);
 
         case "new":
         case "delete":
@@ -458,7 +465,7 @@ public class Client {
           if (newScore.file != null) {
             server.save(newScore.file, newScore.autoConfirm);
           }
-          break;
+          System.exit(0);
 
         case "load":
         case "open":
@@ -479,7 +486,7 @@ public class Client {
               throw new Exception("Please provide some Alda code in the form " +
                                   "of a string, file, or STDIN.");
           }
-          break;
+          System.exit(0);
 
         case "save":
           handleCommandSpecificHelp(jc, "save", save);
@@ -498,7 +505,7 @@ public class Client {
               server.save(file, save.autoConfirm);
               break;
           }
-          break;
+          System.exit(0);
 
         case "edit":
           handleCommandSpecificHelp(jc, "edit", edit);
@@ -532,7 +539,7 @@ public class Client {
 
           Util.runProgramInFg(editor, scoreInfo.filename);
           server.loadWithoutAsking(file);
-          break;
+          System.exit(0);
       }
     } catch (Exception e) {
       server.error(e.getMessage());

--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -1,20 +1,34 @@
 # Development Guide
 
-## Building the Project
+## What You'll Need
 
-The Alda client and server are packaged together in the same uberjar. You can build the project by running a single command (requires [Boot](http://boot-clj.com)), `boot build`, while in the root directory of this repo. Note that this command requires an `-o/--output-dir` argument, which is the directory where the executable files `alda` and `alda.exe` will be written. I like to use `/tmp` (`boot build -o /tmp`). I can then try out changes by running `/tmp/alda <cli args here>`.
+* The Alda project uses [Boot](http://boot-clj.com) to build releases from the Java/Clojure source, as well as to perform useful development tasks like running tests. You will need Boot in order to test any changes you make to the source code.
 
-> The `build` task requires [Launch4j](http://launch4j.sourceforge.net) in order to build the Windows executable.
->
-> (If you're on a Mac with [Homebrew](http://brew.sh) installed, you can install Launch4j by running `brew install launch4j`.)
+  > The `boot` commands described in this guide need to be run while in the root directory of this project, which contains the project file `build.boot`.
 
-Note that the client forks server processes into the background, which continue to run even after the client has exited. If you're testing out changes you've made to the server code, you will need to restart the server by running `alda restart`, which will stop the server and start a new process using your new build.
+  To test changes to the Alda server, client, or REPL, there is a convenient `boot dev` task that requires no additional setup beyond installing Boot. For more information on `boot dev`, see the sections below on the Alda client, server, and REPL.
+
+* (Optional) The `boot build` task (used to build the `alda`/`alda.exe` executables) requires two additional things:
+
+  * [Launch4j](http://launch4j.sourceforge.net) is needed in order to build the Windows executable.
+
+    If you're on a Mac with [Homebrew](http://brew.sh) installed, you can install Launch4j by running:
+
+        brew install launch4j
+
+  * [Java Development Kit 7](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html) is needed in order to create executables that will run on systems that have Java 7+.
+
+    After installing JDK7, set the environment variable `JDK7_BOOTCLASSPATH` to the path to your JDK7 classpath jar. This location will vary depending on your OS. On my Mac, the path is `/Library/Java/JavaVirtualMachines/jdk1.7.0_71.jdk/Contents/Home/jre/lib/rt.jar`.
 
 ## Testing changes
 
-### Running tests
+### Manual testing
 
-You should run `boot test` prior to submitting any Pull Request involving changes to the server. This will run automated tests that live in the `server/test` directory.
+The Alda client, server, and REPL can each be run in development (including any changes you've made to your copy of the code) via the convenient `boot dev` task. See the sections below on the client, server, and REPL for details.
+
+### Unit tests
+
+You should run `boot test` prior to submitting any Pull Request involving changes to the server (Clojure) code. This will run automated tests that live in the `server/test` directory.
 
 #### Adding tests
 
@@ -22,19 +36,72 @@ It is generally good to add to the existing tests wherever it makes sense, i.e. 
 
 If you find yourself adding a new file to the tests, be sure to add its namespace to the `test` task option in `build.boot` so that it will be included when you run the tests via `boot test`.
 
+The automated test battery includes parsing and evaluating all of the example Alda scores in the `examples/` directory. If you add an additional example score, be sure to add it to the list of score files in `server/test/alda/examples_test.clj`.
+
+## Building the Project
+
+The Alda client, server and REPL are packaged together in the same uberjar. You can build the project by running:
+
+    boot build -o /path/to/output-dir/
+
+This will build the `alda` and `alda.exe` executables and place them in the output directory of your choice.
+
 ## Client
+
+### Overview
 
 The Alda client is a fairly straightforward Java CLI app that uses [JCommander](http://jcommander.org) to parse command-line arguments.
 
 Interaction with servers is done via simple HTTP requests. Unless specified via the `-H/--host` option, the Alda client assumes the servers are run locally and sends requests to localhost. The default port is 27713.
 
-Running `alda start` forks a new Alda process in the background, passing it the (hidden) `server` command to start the server. Server output is hidden from the user (though the client will report errors). To see server output for development purposes, you can start a server in the foreground by running `alda server`. You may specify a port via the `-p/--port` option (e.g. `alda -p 2000 server`) -- just make sure you're sending requests from the client to the right port (e.g. `alda -p 2000 play -f my-score.alda`).
+Running `alda start` forks a new Alda process in the background, passing it the (hidden) `server` command to start the server. Server output is hidden from the user (though the client will report errors).
 
-To stop a server, run `alda stop`. To restart a server (e.g. to try out changes to the server code), run `alda restart` after re-building the project.
+To see server output for development purposes, you can start a server in the foreground by running `alda server`. You may specify a port via the `-p/--port` option (e.g. `alda -p 2000 server`) -- just make sure you're sending requests from the client to the right port (e.g. `alda -p 2000 play -f my-score.alda`).
+
+To stop a running server, run `alda stop`.
+
+### Development
+
+To run the Alda client locally to test changes you've made to the code, you can run:
+
+    boot dev -a client -x "args here"
+
+For example, to test changes to the way the `alda play` command plays a file, you can run:
+
+    boot dev -a client -x "play --file /path/to/file.alda"
+
+If you'd prefer, you can do a development build, outputting the executables to a directory of your choice (I like to use `/tmp`), and use the outputted executable:
+
+    boot build -o /tmp
+    /tmp/alda play --file /path/to/file.alda
+
+Note that the client forks server processes into the background, which continue to run even after the client has exited. If you're testing out changes you've made to the server code, you will need to restart the server by running `alda restart`, which will stop the server and start a new process using your new build.
 
 ## Server
 
+### Overview
+
 The Alda server is written in Clojure. It handles a variety of things, including parsing Alda code into executable Clojure code, executing the code to create or modify a score, modeling a musical score as a Clojure map of data, and using the map of data as input to interpret the score (generating sound).
+
+### Development
+
+#### Alda Server
+
+To run an Alda server with any local changes you've made:
+
+    boot dev -a server --port 27713 --alda-fingerprint
+
+The `--port` and `--alda-fingerprint` arguments are strictly optional, but including them will ensure that the Alda client recognizes your development server as an Alda server and includes it in the output of `alda list`.
+
+There is a middleware built into the development server that reloads all of the server namespaces before each request. This makes it so that the server does not need to be restarted each time you make a change to the code.
+
+#### Alda REPL
+
+To run an Alda REPL with any local changes you've made:
+
+    boot dev -a repl
+
+### Namespaces
 
 * [alda.parser](#aldaparser)
 * [alda.lisp](#aldalisp)
@@ -43,7 +110,7 @@ The Alda server is written in Clojure. It handles a variety of things, including
 * [alda.repl](#aldarepl)
 * [alda.server](#aldaserver)
 
-### alda.parser
+#### alda.parser
 
 Parsing begins with the `parse-input` function in the [`alda.parser`](https://github.com/alda-lang/alda/blob/master/server/src/alda/parser.clj) namespace. This function uses a series of parsers built using [Instaparse](https://github.com/Engelberg/instaparse), an excellent parser-generator library for Clojure.
 The grammars for each step of the parsing process are composed from [small files written in BNF](https://github.com/alda-lang/alda/blob/master/server/grammar) (with some Instaparse-specific sugar); if you find yourself editing any of these files, it may be helpful to read up on Instaparse. [The tutorial in the Instaparse README](https://github.com/Engelberg/instaparse) is comprehensive and excellent.
@@ -98,7 +165,7 @@ alda.parser=> (parse-input "piano: c8 e g c1/f/a")
         (alda.lisp/pitch :a)))))
 ```
 
-### alda.lisp
+#### alda.lisp
 
 When you evaluate a score [S-expression](https://en.wikipedia.org/wiki/S-expression) like the one above, the result is a map of score information, which provides all of the data that Alda's audio component needs to make an audible version of your score.
 
@@ -191,7 +258,7 @@ Because `alda.lisp` is a Clojure DSL, it's possible to use it to build scores wi
     (note (pitch :c))))
 ```
 
-### alda.sound
+#### alda.sound
 
 The `alda.sound` namespace handles the implementation details of playing the score.
 
@@ -201,11 +268,11 @@ The `play!` function handles playing an entire Alda score. It does this by using
 
 What happens, exactly, at the beginning and end of an event, is determined by the `start-event!`/`stop-event!` implementations for each instrument type. For example, for MIDI instruments, `start-event!` sets parameters such as volume and panning and sends a MIDI note-on message at the beginning of the score plus `:offset` milliseconds, and `stop-event!` sends a note-off message `:duration` milliseconds later.
 
-#### alda.lisp.instruments
+##### alda.lisp.instruments
 
 Although technically a part of `alda.lisp`, stock instrument configurations are defined here, which are included in an Alda score map, and then used by `alda.sound` to provide details about how to play an instrument's note events. Each instrument's `:config` field is available to the `alda.sound/play-event!` function via the `:instrument` field of the event.
 
-### alda.repl
+#### alda.repl
 
 `alda.repl` is the codebase for Alda's **R**ead-**E**val-**P**lay **L**oop, which lets you build a score interactively by entering Alda code one line at a time.
 
@@ -213,7 +280,7 @@ There are built-in commands defined in `alda.repl.commands` that are defined usi
 
 The core logic for what goes on behind the curtain when you use the REPL lives in `alda.repl.core`. A good practice for implementing a REPL command in `alda.repl.commands` is to move implementation details into `alda.repl.core` (or perhaps into a new sub-namespace of `alda.repl`, if appropriate) if the body of the command definition starts to get too long.
 
-### alda.server
+#### alda.server
 
 `alda.server/start-server!` is the entrypoint to the Alda server. It starts a Clojure web app using [Ring](https://github.com/ring-clojure/ring) and [Compojure](https://github.com/weavejester/compojure), and serves it via [Jetty](https://en.wikipedia.org/wiki/Jetty_(web_server)).
 

--- a/server/test/alda/examples_test.clj
+++ b/server/test/alda/examples_test.clj
@@ -1,4 +1,4 @@
-(ns alda.parser.examples-test
+(ns alda.examples-test
   (:require [clojure.test    :refer :all]
             [clojure.java.io :as    io]
             [alda.parser     :refer (parse-input)]


### PR DESCRIPTION
* Whereas before, `boot dev` started an Alda server, now the `-a/--app` argument can be used to run an Alda REPL, server, or client based on the current code with any local changes, without having to build the whole project. This should make it quicker and easier to test changes.

  `boot dev -a server --port 12345 --alda-fingerprint` starts a server
  (or just `boot dev --port 12345 --alda-fingerprint`; server is the default)

  `boot dev -a repl` starts an Alda REPL

  `boot dev -a client -x "cli args here"` runs the Alda client with any local changes.
  e.g. `boot dev -a client -x "play --file /path/to/file.alda"` is like running `alda play --file /path/to/file.alda`

* Improved documentation about `boot build` and `boot dev` -- hopefully this will make it a bit easier to get up and running for new people wanting to contribute to Alda.