### PR TITLE
#232 Updating installation script to resolve missing Gervill directory

### DIFF
--- a/scripts/install-fluidr3
+++ b/scripts/install-fluidr3
@@ -14,6 +14,7 @@ curl -O https://repo1.maven.org/maven2/org/bitbucket/daveyarwood/fluid-r3/${FLUI
 mkdir -p ${FLUID_WORK_FOLDER}
 mv ${FLUID_NAME}.jar ${FLUID_WORK_FOLDER}
 cd ${FLUID_WORK_FOLDER} && unzip -qq ${FLUID_NAME}.jar
+mkdir -p ~/.gervill
 cp fluid-r3.sf2 ~/.gervill/soundbank-emg.sf2
 echo "Installed ${FLUID_NAME}"
 cd .. && rm -rf ${FLUID_WORK_FOLDER}


### PR DESCRIPTION
Providing a PR to resolve [issue 232](https://github.com/alda-lang/alda/issues/232) — that the FluidR3 script will fail if the `~/gervill`directory is missing.

(Please let me know if you need any amends)