### PR TITLE
Parser optimizations

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -21,7 +21,6 @@
                   [io.aviso/pretty        "0.1.20"]
                   [jline                  "2.12.1"]
                   [org.clojars.sidec/jsyn "16.7.3"]
-                  [org.clojure/clojure    "1.7.0"]
                   [potemkin               "0.4.1"]
                   [ring                   "1.4.0"]
                   [ring/ring-defaults     "0.1.5"]

--- a/server/grammar/comments.bnf
+++ b/server/grammar/comments.bnf
@@ -1,4 +1,4 @@
 score         = (non-comment | <comment> | clj-expr)*
 comment       = <"#"> #".*" <#"(\n|\r|$)+">
-<non-comment> = !("#" | "(" | ")") #".|\n|\r"
+<non-comment> = #"[^\#\(\)]+"
 

--- a/server/grammar/duration.bnf
+++ b/server/grammar/duration.bnf
@@ -1,6 +1,5 @@
 duration                = (note-length | seconds | milliseconds)
                           (<ows> barline? <ows> subduration)*
-                          (barline? <ows> slur)?
 <subduration>           = tie <ows> barline? <ows>
                           (note-length | seconds | milliseconds) <ows>
 

--- a/server/grammar/duration.bnf
+++ b/server/grammar/duration.bnf
@@ -1,8 +1,8 @@
 duration                = (note-length | seconds | milliseconds)
-                          <ows> barline? <ows> subduration* slur?
+                          (<ows> barline? <ows> subduration)*
+                          (barline? <ows> slur)?
 <subduration>           = tie <ows> barline? <ows>
                           (note-length | seconds | milliseconds) <ows>
-                          barline? <ows>
 
 seconds                 = positive-number <"s">
 milliseconds            = positive-number <"ms">

--- a/server/grammar/score.bnf
+++ b/server/grammar/score.bnf
@@ -5,5 +5,5 @@ calls             = name
                     (<ows> <"/"> <ows> name)*
                     (<ows> nickname)?
                     <ows> <":">
-<music-data>      = !part #".|\n|\r"
+<music-data>      = !calls #"[a-zA-Z]*[^a-zA-Z]*([a-zA-Z][^a-zA-Z]+)*"
 

--- a/server/grammar/score.bnf
+++ b/server/grammar/score.bnf
@@ -1,4 +1,4 @@
-score             = <ows> header? <ows> part* <ows>
+score             = <ows> header? part*
 header            = !calls <ows> music-data+
 part              = calls <ows> music-data*
 calls             = name

--- a/server/src/alda/lisp/events/note.clj
+++ b/server/src/alda/lisp/events/note.clj
@@ -129,10 +129,10 @@
     (let [duration (when (map? x) x)
           slur?    (= x :slur)]
       (note pitch-fn duration slur?)))
-  ([pitch-fn {:keys [beats ms slurred]} slur?]
+  ([pitch-fn {:keys [beats ms]} slur?]
      {:event-type :note
       :pitch-fn   pitch-fn
       :beats      beats
       :ms         ms
-      :slur?      (or slur? slurred)}))
+      :slur?      slur?}))
 

--- a/server/src/alda/lisp/model/duration.clj
+++ b/server/src/alda/lisp/model/duration.clj
@@ -65,26 +65,19 @@
    purpose in the parse tree only, and evaluate to `nil` in alda.lisp. This
    function ignores barlines by removing the nils.
 
-   A slur may appear as the final argument of a duration, making the current
-   note legato (effectively slurring it into the next).
-
    Returns a map containing the total number of beats (counting only those
-   note-lengths that are expressed in standard musical notation), the total
+   note-lengths that are expressed in standard musical notation) and the total
    number of milliseconds (counting only those note-lengths expressed in
-   milliseconds), and whether or not the note is slurred.
+   milliseconds).
 
    This information is used by events (like notes and rests) to calculate the
    total duration in milliseconds (as this depends on the score's time-scaling
    factor and the tempo of the instrument the event belongs to)."
   [& components]
-  (let [components (remove nil? components)
-        [note-lengths slurred] (if (= (last components) :slur)
-                                 (conj [(drop-last components)] true)
-                                 (conj [components] false))
-        note-lengths (map (fn [x] (if (map? x)
-                                    x
-                                    {:type :beats, :value x}))
-                          note-lengths)
+  (let [note-lengths     (map (fn [x] (if (map? x)
+                                        x
+                                        {:type :beats, :value x}))
+                              (remove nil? components))
         beats-components (for [{:keys [type value]} note-lengths
                                :when (= type :beats)]
                            value)
@@ -94,6 +87,5 @@
                          value))]
     {:beats     beats
      :ms        ms
-     :slurred   slurred
      :duration? true} ; identify this as a duration map
     ))

--- a/server/test/alda/lisp/duration_test.clj
+++ b/server/test/alda/lisp/duration_test.clj
@@ -59,7 +59,7 @@
   (testing "slurred notes ignore quantization"
     (let [s      (score
                    (part "piano" (tempo 120) (quant 90)
-                     (note (pitch :c) (duration (note-length 4) :slur))))
+                     (note (pitch :c) (duration (note-length 4)) :slur)))
           piano  (get-instrument s "piano")
           events (:events s)]
       (is (== 500 (:duration (first events)))))

--- a/server/test/alda/lisp/notes_test.clj
+++ b/server/test/alda/lisp/notes_test.clj
@@ -10,7 +10,7 @@
           start (:current-offset piano)
           c     ((pitch :c) (:octave piano) (:key-signature piano))
           s     (continue s
-                  (note (pitch :c) (duration (note-length 4) :slur)))
+                  (note (pitch :c) (duration (note-length 4)) :slur))
           piano (get-instrument s "piano")
           {:keys [duration offset pitch] :as note} (first (:events s))]
       (testing "should be placed at the current offset"


### PR DESCRIPTION
I made a pass through each of Alda's parsers with `instaparse.core/parses` to determine whether there was any ambiguity contributing to slow parse times noted in #208. I did find a few places where there was ambiguity in the grammar -- see the commit messages for more details.

Unfortunately, this is only a minor improvement over what we have now. The major example of a slow-parsing score we have now is the Bach cello suite example. Currently on my computer, that score takes about 800-900 ms to parse. With the improvements on this branch, it takes about 700-800 ms which is barely a difference.

I think the next step is going to be considering some of the other suggestions in the [instaparse wiki's performance tips](https://github.com/Engelberg/instaparse/blob/master/docs/Performance.md#performance-tips). This PR should make performance tip 5 no longer an issue, but maybe performance tip 6 is applicable.

One thing I started playing around with was commenting out certain parts of the parsing pipeline and using `clojure.core/time` to profile the different stages. On my computer, it took about 300 ms just to remove the comments and parse Clojure expressions, which seems fishy.

(WIP PR -- will leave open, at least for now. I'd love some feedback, if anyone reading this happens to be knowledgeable about parsing and/or can help determine the causes of Alda's slowness in parsing larger scores.)