### PR TITLE
Parser optimizations + "Method code too large!" fix

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -21,7 +21,6 @@
                   [io.aviso/pretty        "0.1.20"]
                   [jline                  "2.12.1"]
                   [org.clojars.sidec/jsyn "16.7.3"]
-                  [org.clojure/clojure    "1.7.0"]
                   [potemkin               "0.4.1"]
                   [ring                   "1.4.0"]
                   [ring/ring-defaults     "0.1.5"]

--- a/build.boot
+++ b/build.boot
@@ -99,6 +99,7 @@
                           alda.lisp.attributes-test
                           alda.lisp.cram-test
                           alda.lisp.chords-test
+                          alda.lisp.code-test
                           alda.lisp.duration-test
                           alda.lisp.global-attributes-test
                           alda.lisp.markers-test

--- a/client/src/alda/Client.java
+++ b/client/src/alda/Client.java
@@ -69,7 +69,7 @@ public class Client {
   @Parameters(commandDescription = "Display this help text")
   private static class CommandHelp extends AldaCommand {}
 
-  @Parameters(commandDescription = "Attempt to autoupdate alda")
+  @Parameters(commandDescription = "Download and install the latest release of Alda")
   private static class CommandUpdate extends AldaCommand {}
 
   @Parameters(commandDescription = "Start the Alda server")

--- a/server/grammar/comments.bnf
+++ b/server/grammar/comments.bnf
@@ -1,4 +1,4 @@
 score         = (non-comment | <comment> | clj-expr)*
 comment       = <"#"> #".*" <#"(\n|\r|$)+">
-<non-comment> = !("#" | "(" | ")") #".|\n|\r"
+<non-comment> = #"[^\#\(\)]+"
 

--- a/server/grammar/duration.bnf
+++ b/server/grammar/duration.bnf
@@ -1,6 +1,5 @@
 duration                = (note-length | seconds | milliseconds)
                           (<ows> barline? <ows> subduration)*
-                          (barline? <ows> slur)?
 <subduration>           = tie <ows> barline? <ows>
                           (note-length | seconds | milliseconds) <ows>
 

--- a/server/grammar/duration.bnf
+++ b/server/grammar/duration.bnf
@@ -1,8 +1,8 @@
 duration                = (note-length | seconds | milliseconds)
-                          <ows> barline? <ows> subduration* slur?
+                          (<ows> barline? <ows> subduration)*
+                          (barline? <ows> slur)?
 <subduration>           = tie <ows> barline? <ows>
                           (note-length | seconds | milliseconds) <ows>
-                          barline? <ows>
 
 seconds                 = positive-number <"s">
 milliseconds            = positive-number <"ms">

--- a/server/grammar/score.bnf
+++ b/server/grammar/score.bnf
@@ -5,5 +5,5 @@ calls             = name
                     (<ows> <"/"> <ows> name)*
                     (<ows> nickname)?
                     <ows> <":">
-<music-data>      = !part #".|\n|\r"
+<music-data>      = !calls #"[a-zA-Z]*[^a-zA-Z]*([a-zA-Z][^a-zA-Z]+)*"
 

--- a/server/grammar/score.bnf
+++ b/server/grammar/score.bnf
@@ -1,4 +1,4 @@
-score             = <ows> header? <ows> part* <ows>
+score             = <ows> header? part*
 header            = !calls <ows> music-data+
 part              = calls <ows> music-data*
 calls             = name

--- a/server/src/alda/lisp.clj
+++ b/server/src/alda/lisp.clj
@@ -7,14 +7,15 @@
 ; sets log level to TIMBRE_LEVEL (if set) or :warn
 (util/set-timbre-level!)
 
-(defn import-all-vars
+(defn- import-all-vars
   "Imports all public vars from a namespace into the alda.lisp namespace."
   [ns]
   (eval (list `import-vars (cons ns (keys (ns-publics ns))))))
 
-(def namespaces
+(def ^:private namespaces
   '[alda.lisp.attributes
     alda.lisp.code
+    alda.lisp.events
     alda.lisp.events.barline
     alda.lisp.events.chord
     alda.lisp.events.cram

--- a/server/src/alda/lisp/attributes.clj
+++ b/server/src/alda/lisp/attributes.clj
@@ -1,9 +1,9 @@
 (ns alda.lisp.attributes
-  (:require [alda.lisp.model.attribute        :refer (set-attribute
-                                                      *attribute-table*)]
-            [alda.lisp.model.global-attribute :refer (global-attribute)]
-            [alda.lisp.model.key              :refer (get-key-signature)]
-            [alda.lisp.model.records          :refer (->AbsoluteOffset
+  (:require [alda.lisp.events          :refer (global-attribute)]
+            [alda.lisp.model.attribute :refer (set-attribute
+                                               *attribute-table*)]
+            [alda.lisp.model.key       :refer (get-key-signature)]
+            [alda.lisp.model.records   :refer (->AbsoluteOffset
                                                       ->Attribute)]))
 
 (comment

--- a/server/src/alda/lisp/code.clj
+++ b/server/src/alda/lisp/code.clj
@@ -1,12 +1,12 @@
 (ns alda.lisp.code
-  (:require [alda.parser-util :refer (parse-with-context)]))
+  (:require [alda.parser-util :refer (parse-to-lisp-with-context)]))
 
 (defn alda-code
   "Attempts to parse a string of text within the context of the current score;
    if the code parses successfully, the result is one or more events that are
    spliced into the score."
   [code]
-  (let [[context parse-result] (parse-with-context code)]
+  (let [[context parse-result] (parse-to-lisp-with-context code)]
     (eval (case context
             :music-data    (cons 'vector parse-result)
             :score         (cons 'vector (rest parse-result))

--- a/server/src/alda/lisp/code.clj
+++ b/server/src/alda/lisp/code.clj
@@ -13,7 +13,3 @@
             :parse-failure (throw (Exception. (str "Invalid Alda code: " code)))
             parse-result))))
 
-(defn times
-  "Repeats an Alda event (or sequence of events) `n` times."
-  [n event]
-  (repeat n event))

--- a/server/src/alda/lisp/code.clj
+++ b/server/src/alda/lisp/code.clj
@@ -1,15 +1,12 @@
 (ns alda.lisp.code
-  (:require [alda.parser-util :refer (parse-to-lisp-with-context)]))
+  (:require [alda.parser-util :refer (parse-to-events-with-context)]))
 
 (defn alda-code
   "Attempts to parse a string of text within the context of the current score;
    if the code parses successfully, the result is one or more events that are
    spliced into the score."
   [code]
-  (let [[context parse-result] (parse-to-lisp-with-context code)]
-    (eval (case context
-            :music-data    (cons 'vector parse-result)
-            :score         (cons 'vector (rest parse-result))
-            :parse-failure (throw (Exception. (str "Invalid Alda code: " code)))
-            parse-result))))
-
+  (let [[context parse-result] (parse-to-events-with-context code)]
+    (if (= context :parse-failure)
+      (throw (Exception. (str "Invalid Alda code: " code)))
+      parse-result)))

--- a/server/src/alda/lisp/events.clj
+++ b/server/src/alda/lisp/events.clj
@@ -1,0 +1,153 @@
+(ns alda.lisp.events
+  "Convenience functions for generating Alda events.
+
+   These functions comprise the event functions in the alda.lisp DSL."
+  (:require [alda.lisp.model.attribute :refer (get-attr)]))
+
+(defn part
+  "Determines the current instrument instance(s) based on the `instrument-call`
+   and evaluates the `events` within that context.
+
+   `instrument-call` can either be a map containing :names and an optional
+   :nickname (e.g. {:names ['piano' 'trumpet'] :nickname ['trumpiano']}) or a
+   valid Alda instrument call string, e.g. 'piano/trumpet 'trumpiano''."
+  [instrument-call & events]
+  {:event-type      :part
+   :instrument-call instrument-call
+   :events          events})
+
+(defn note
+  "Causes every instrument in :current-instruments to play a note at its
+   :current-offset for the specified duration.
+
+   If no duration is specified, the note is played for the instrument's own
+   internal duration, which will be the duration last specified on a note or
+   rest in that instrument's part."
+  ([pitch-fn]
+    (note pitch-fn nil false))
+  ([pitch-fn x]
+    ; x could be a duration or :slur
+    (let [duration (when (map? x) x)
+          slur?    (= x :slur)]
+      (note pitch-fn duration slur?)))
+  ([pitch-fn {:keys [beats ms slurred]} slur?]
+     {:event-type :note
+      :pitch-fn   pitch-fn
+      :beats      beats
+      :ms         ms
+      :slur?      (or slur? slurred)}))
+
+(defn pause
+  "Causes every instrument in :current-instruments to rest (not play) for the
+   specified duration.
+
+   If no duration is specified, each instrument will rest for its own internal
+   duration, which will be the duration last specified on a note or rest in
+   that instrument's part."
+  [& [{:keys [beats ms] :as dur}]]
+   {:event-type :rest
+    :beats      beats
+    :ms         ms})
+
+(defn chord
+  "Causes every instrument in :current-instruments to play each note in the
+   chord simultaneously at the instrument's :current-offset."
+  [& events]
+  {:event-type :chord
+   :events     events})
+
+(defn global-attribute
+  "Public fn for setting global attributes in a score.
+   e.g. (global-attribute :tempo 100)"
+  [attr val]
+  {:event-type :global-attribute-change
+   :attr       (:kw-name (get-attr attr))
+   :val        val})
+
+(defn global-attributes
+  "Convenience fn for setting multiple global attributes at once.
+   e.g. (global-attributes :tempo 100 :volume 50)"
+  [& attrs]
+  (for [[attr val] (partition 2 attrs)]
+    (global-attribute attr val)))
+
+(defn apply-global-attributes
+  "For each instrument in :current-instruments, looks between the instrument's
+   :last-offset and :current-offset and applies any attribute changes occurring
+   within that window.
+
+   Both global and per-instrument attributes are applied; in the case that a
+   per-instrument attribute is applied at the exact same time as a global
+   attribute, the per-instrument attribute takes precedence for that instrument."
+  []
+  {:event-type :apply-global-attributes})
+
+(defn barline
+  "Barlines, at least currently, do nothing when evaluated in alda.lisp."
+  []
+  nil)
+
+(defn marker
+  "Places a marker at the current absolute offset. Throws an exception if there
+   are multiple instruments active at different offsets."
+  [name]
+  {:event-type :marker
+   :name       name})
+
+(defn at-marker
+  "Set the marker at which events will be added."
+  [name]
+  {:event-type :at-marker
+   :name       name})
+
+(defn voice
+  "One voice in a voice group."
+  [voice-number & events]
+  {:event-type :voice
+   :number     voice-number
+   :events     events})
+
+(defn voices
+  "Voices are chronological sequences of events that each start at the same
+   time. The resulting :current-offset is at the end of the voice that finishes
+   last."
+  [& voices]
+  {:event-type :voice-group
+   :voices     voices})
+
+(defn end-voices
+  "By default, the score remains in 'voice mode' until it reaches an end-voices
+   event. This is so that if an instrument part ends with a voice group, the
+   same voices can be appended later if the part is resumed, e.g. when building
+   a score gradually in the Alda REPL or in a Clojure process.
+
+   The end-voices event is emitted by the parser when it parses 'V0:'."
+  []
+  {:event-type :end-voice-group})
+
+(defn times
+  "Repeats an Alda event (or sequence of events) `n` times."
+  [n event]
+  (repeat n event))
+
+(defn cram
+  "A cram expression evaluates the events it contains, time-scaled based on the
+   inner tally of beats in the events and the outer durations of each current
+   instrument."
+  [& events]
+  (let [[duration & events] (if (:duration? (last events))
+                              (cons (last events) (butlast events))
+                              (cons nil events))]
+    {:event-type :cram
+     :duration   duration
+     :events     events}))
+
+(defn schedule
+  "Schedules an arbitrary function to be called at the current point in the
+   score (determined by the current instrument's marker and offset).
+
+   If there are multiple current instruments, the function will be executed
+   once for each instrument, at the marker + offset of that instrument."
+  [f]
+  {:event-type :function
+   :function   f})

--- a/server/src/alda/lisp/events/barline.clj
+++ b/server/src/alda/lisp/events/barline.clj
@@ -1,6 +1,4 @@
 (ns alda.lisp.events.barline)
 
-(defn barline
-  "Barlines, at least currently, do nothing when evaluated in alda.lisp."
-  []
-  nil)
+(comment "Barlines, at least currently, do nothing when evaluated in alda.lisp.")
+

--- a/server/src/alda/lisp/events/chord.clj
+++ b/server/src/alda/lisp/events/chord.clj
@@ -48,9 +48,3 @@
         bump-by-min-durations
         (assoc :chord-mode false))))
 
-(defn chord
-  "Causes every instrument in :current-instruments to play each note in the
-   chord simultaneously at the instrument's :current-offset."
-  [& events]
-  {:event-type :chord
-   :events     events})

--- a/server/src/alda/lisp/events/cram.clj
+++ b/server/src/alda/lisp/events/cram.clj
@@ -2,7 +2,7 @@
   (:require [alda.lisp.model.event :refer (update-score add-events)]
             [alda.lisp.score.util  :refer (update-instruments)]))
 
-(defn tally-beats
+(defn- tally-beats
   [score events]
   (-> score
       (assoc :beats-tally 0
@@ -10,14 +10,14 @@
       (#(reduce update-score % events))
       :beats-tally))
 
-(defn calculate-time-scaling
+(defn- calculate-time-scaling
   "Given an existing time-scaling value (the default is 1, when not already
    inside of a cram), the 'inner' length of a cram in beats, and the 'outer'
    length of the cram in beats, calculates the effective time-scaling value."
   [time-scaling inner-beats outer-beats]
   (* (/ time-scaling inner-beats) outer-beats))
 
-(defn set-time-scaling
+(defn- set-time-scaling
   "Sets the time-scaling value of each instrument, based on its existing
    time-scaling and duration values and the inner and (optional) outer beats
    tally of the CRAM expression.
@@ -38,7 +38,7 @@
             (update :previous-time-scaling (fnil conj []) time-scaling)
             (assoc :time-scaling new-time-scaling))))))
 
-(defn reset-time-scaling
+(defn- reset-time-scaling
   [score]
   (update-instruments score
     (fn [{:keys [previous-time-scaling] :as inst}]
@@ -46,7 +46,7 @@
           (assoc :time-scaling (peek previous-time-scaling))
           (update :previous-time-scaling pop)))))
 
-(defn set-initial-duration-inside-cram
+(defn- set-initial-duration-inside-cram
   "Sets the initial :duration-inside-cram value for each instrument to 1 beat.
    As events inside the cram are added, :duration-inside-cram is updated instead
    of :duration."
@@ -58,7 +58,7 @@
                   (fnil conj []) duration-inside-cram)
           (assoc  :duration-inside-cram 1)))))
 
-(defn reset-duration-inside-cram
+(defn- reset-duration-inside-cram
   "Removes the :duration-inside-cram value for each instrument."
   [score]
   (update-instruments score
@@ -89,16 +89,4 @@
                                       inst)))
             %))
         (update :cram-level dec))))
-
-(defn cram
-  "A cram expression evaluates the events it contains, time-scaled based on the
-   inner tally of beats in the events and the outer durations of each current
-   instrument."
-  [& events]
-  (let [[duration & events] (if (:duration? (last events))
-                              (cons (last events) (butlast events))
-                              (cons nil events))]
-    {:event-type :cram
-     :duration   duration
-     :events     events}))
 

--- a/server/src/alda/lisp/events/fn.clj
+++ b/server/src/alda/lisp/events/fn.clj
@@ -12,12 +12,3 @@
                              (->Function current-offset id function))
                            (get-current-instruments score)))))
 
-(defn schedule
-  "Schedules an arbitrary function to be called at the current point in the
-   score (determined by the current instrument's marker and offset).
-
-   If there are multiple current instruments, the function will be executed
-   once for each instrument, at the marker + offset of that instrument."
-  [f]
-  {:event-type :function
-   :function   f})

--- a/server/src/alda/lisp/events/note.clj
+++ b/server/src/alda/lisp/events/note.clj
@@ -1,13 +1,13 @@
 (ns alda.lisp.events.note
-  (:require [alda.lisp.model.global-attribute :refer (apply-global-attributes)]
-            [alda.lisp.model.duration         :refer (calculate-duration)]
-            [alda.lisp.model.event            :refer (update-score add-events)]
-            [alda.lisp.model.offset           :refer (offset+)]
-            [alda.lisp.model.records          :refer (map->Note)]
-            [alda.lisp.score.util             :refer (merge-instruments
-                                                      merge-voice-instruments
-                                                      get-current-instruments)]
-            [taoensso.timbre                  :as    log]))
+  (:require [alda.lisp.events         :refer (apply-global-attributes)]
+            [alda.lisp.model.duration :refer (calculate-duration)]
+            [alda.lisp.model.event    :refer (update-score add-events)]
+            [alda.lisp.model.offset   :refer (offset+)]
+            [alda.lisp.model.records  :refer (map->Note)]
+            [alda.lisp.score.util     :refer (merge-instruments
+                                              merge-voice-instruments
+                                              get-current-instruments)]
+            [taoensso.timbre          :as    log]))
 
 (defn- event-updates
   "Given a score and a (note/rest) event, returns a list of updates for each
@@ -114,25 +114,4 @@
   (-> score
       (add-note-or-rest note)
       (update-score (apply-global-attributes))))
-
-(defn note
-  "Causes every instrument in :current-instruments to play a note at its
-   :current-offset for the specified duration.
-
-   If no duration is specified, the note is played for the instrument's own
-   internal duration, which will be the duration last specified on a note or
-   rest in that instrument's part."
-  ([pitch-fn]
-    (note pitch-fn nil false))
-  ([pitch-fn x]
-    ; x could be a duration or :slur
-    (let [duration (when (map? x) x)
-          slur?    (= x :slur)]
-      (note pitch-fn duration slur?)))
-  ([pitch-fn {:keys [beats ms]} slur?]
-     {:event-type :note
-      :pitch-fn   pitch-fn
-      :beats      beats
-      :ms         ms
-      :slur?      slur?}))
 

--- a/server/src/alda/lisp/events/note.clj
+++ b/server/src/alda/lisp/events/note.clj
@@ -129,10 +129,10 @@
     (let [duration (when (map? x) x)
           slur?    (= x :slur)]
       (note pitch-fn duration slur?)))
-  ([pitch-fn {:keys [beats ms slurred]} slur?]
+  ([pitch-fn {:keys [beats ms]} slur?]
      {:event-type :note
       :pitch-fn   pitch-fn
       :beats      beats
       :ms         ms
-      :slur?      (or slur? slurred)}))
+      :slur?      slur?}))
 

--- a/server/src/alda/lisp/events/rest.clj
+++ b/server/src/alda/lisp/events/rest.clj
@@ -1,7 +1,7 @@
 (ns alda.lisp.events.rest
-  (:require [alda.lisp.model.global-attribute :refer (apply-global-attributes)]
-            [alda.lisp.events.note            :refer (add-note-or-rest)]
-            [alda.lisp.model.event            :refer (update-score)]))
+  (:require [alda.lisp.events      :refer (apply-global-attributes)]
+            [alda.lisp.events.note :refer (add-note-or-rest)]
+            [alda.lisp.model.event :refer (update-score)]))
 
 (comment
   "Implementation-wise, a rest is just a note without a pitch, so a rest event
@@ -13,16 +13,4 @@
   (-> score
       (add-note-or-rest rest-event)
       (update-score (apply-global-attributes))))
-
-(defn pause
-  "Causes every instrument in :current-instruments to rest (not play) for the
-   specified duration.
-
-   If no duration is specified, each instrument will rest for its own internal
-   duration, which will be the duration last specified on a note or rest in
-   that instrument's part."
-  [& [{:keys [beats ms] :as dur}]]
-   {:event-type :rest
-    :beats      beats
-    :ms         ms})
 

--- a/server/src/alda/lisp/events/voice.clj
+++ b/server/src/alda/lisp/events/voice.clj
@@ -42,27 +42,3 @@
   [score _]
   (end-voice-group score))
 
-(defn voice
-  "One voice in a voice group."
-  [voice-number & events]
-  {:event-type :voice
-   :number     voice-number
-   :events     events})
-
-(defn voices
-  "Voices are chronological sequences of events that each start at the same
-   time. The resulting :current-offset is at the end of the voice that finishes
-   last."
-  [& voices]
-  {:event-type :voice-group
-   :voices     voices})
-
-(defn end-voices
-  "By default, the score remains in 'voice mode' until it reaches an end-voices
-   event. This is so that if an instrument part ends with a voice group, the
-   same voices can be appended later if the part is resumed, e.g. when building
-   a score gradually in the Alda REPL or in a Clojure process.
-
-   The end-voices event is emitted by the parser when it parses 'V0:'."
-  []
-  {:event-type :end-voice-group})

--- a/server/src/alda/lisp/model/duration.clj
+++ b/server/src/alda/lisp/model/duration.clj
@@ -65,26 +65,19 @@
    purpose in the parse tree only, and evaluate to `nil` in alda.lisp. This
    function ignores barlines by removing the nils.
 
-   A slur may appear as the final argument of a duration, making the current
-   note legato (effectively slurring it into the next).
-
    Returns a map containing the total number of beats (counting only those
-   note-lengths that are expressed in standard musical notation), the total
+   note-lengths that are expressed in standard musical notation) and the total
    number of milliseconds (counting only those note-lengths expressed in
-   milliseconds), and whether or not the note is slurred.
+   milliseconds).
 
    This information is used by events (like notes and rests) to calculate the
    total duration in milliseconds (as this depends on the score's time-scaling
    factor and the tempo of the instrument the event belongs to)."
   [& components]
-  (let [components (remove nil? components)
-        [note-lengths slurred] (if (= (last components) :slur)
-                                 (conj [(drop-last components)] true)
-                                 (conj [components] false))
-        note-lengths (map (fn [x] (if (map? x)
-                                    x
-                                    {:type :beats, :value x}))
-                          note-lengths)
+  (let [note-lengths     (map (fn [x] (if (map? x)
+                                        x
+                                        {:type :beats, :value x}))
+                              (remove nil? components))
         beats-components (for [{:keys [type value]} note-lengths
                                :when (= type :beats)]
                            value)
@@ -94,6 +87,5 @@
                          value))]
     {:beats     beats
      :ms        ms
-     :slurred   slurred
      :duration? true} ; identify this as a duration map
     ))

--- a/server/src/alda/lisp/model/global_attribute.clj
+++ b/server/src/alda/lisp/model/global_attribute.clj
@@ -1,6 +1,5 @@
 (ns alda.lisp.model.global-attribute
-  (:require [alda.lisp.model.attribute :refer (get-attr
-                                               set-attribute
+  (:require [alda.lisp.model.attribute :refer (set-attribute
                                                apply-attribute)]
             [alda.lisp.model.event     :refer (update-score)]
             [alda.lisp.model.offset    :refer (absolute-offset
@@ -22,22 +21,7 @@
                   "unclear. There are multiple instruments active with "
                   "different time offsets.")))))
 
-(defn global-attribute
-  "Public fn for setting global attributes in a score.
-   e.g. (global-attribute :tempo 100)"
-  [attr val]
-  {:event-type :global-attribute-change
-   :attr       (:kw-name (get-attr attr))
-   :val        val})
-
-(defn global-attributes
-  "Convenience fn for setting multiple global attributes at once.
-   e.g. (global-attributes :tempo 100 :volume 50)"
-  [& attrs]
-  (for [[attr val] (partition 2 attrs)]
-    (global-attribute attr val)))
-
-(defn global-attribute-changes
+(defn- global-attribute-changes
   "Determines the attribute changes to apply to an instrument, based on the
    attribute changes established in the score (global attributes) and the
    instrument's :last- and :current-offset.
@@ -75,15 +59,4 @@
                   inst
                   attr-changes))
         inst))))
-
-(defn apply-global-attributes
-  "For each instrument in :current-instruments, looks between the instrument's
-   :last-offset and :current-offset and applies any attribute changes occurring
-   within that window.
-
-   Both global and per-instrument attributes are applied; in the case that a
-   per-instrument attribute is applied at the exact same time as a global
-   attribute, the per-instrument attribute takes precedence for that instrument."
-  []
-  {:event-type :apply-global-attributes})
 

--- a/server/src/alda/lisp/model/marker.clj
+++ b/server/src/alda/lisp/model/marker.clj
@@ -36,16 +36,3 @@
             (assoc :current-offset (->RelativeOffset name 0)))
         inst))))
 
-(defn marker
-  "Places a marker at the current absolute offset. Throws an exception if there
-   are multiple instruments active at different offsets."
-  [name]
-  {:event-type :marker
-   :name       name})
-
-(defn at-marker
-  "Set the marker at which events will be added."
-  [name]
-  {:event-type :at-marker
-   :name       name})
-

--- a/server/src/alda/lisp/score/part.clj
+++ b/server/src/alda/lisp/score/part.clj
@@ -6,7 +6,7 @@
             [alda.lisp.events.voice     :refer (end-voice-group)]
             [alda.lisp.model.event      :refer (update-score)]
             [alda.lisp.model.instrument :refer (*stock-instruments*)]
-            [alda.parser-util           :refer (parse-with-context)]))
+            [alda.parser-util           :refer (parse-to-lisp-with-context)]))
 
 (defn- generate-id
   [name]
@@ -93,10 +93,10 @@
                  :current-instruments (set instances))))
 
 (defn- parse-instrument-call [s]
-  (parse-with-context :calls (-> s
-                                 (str/replace #":$" "")
-                                 (str/replace #"'" "\"")
-                                 (str \:))))
+  (parse-to-lisp-with-context :calls (-> s
+                                         (str/replace #":$" "")
+                                         (str/replace #"'" "\"")
+                                         (str \:))))
 
 (defmethod update-score :part
   [score {:keys [instrument-call events] :as part}]

--- a/server/src/alda/parser.clj
+++ b/server/src/alda/parser.clj
@@ -133,14 +133,17 @@
        header-parser
        check-for-failure
        (insta/transform
-         (case mode
-           :lisp
-           {:header          #(list* %&)
-            :clj-expr-cached #(get-from-cache cache %)}
+         (let [lisp-xforms
+               {:header          #(list* %&)
+                :clj-expr-cached #(get-from-cache cache %)}
 
-           :map
-           {:header          vector
-            :clj-expr-cached #(eval (get-from-cache cache %))}))))
+               map-xforms
+               {:header          vector
+                :clj-expr-cached #(eval (get-from-cache cache %))}]
+           (case mode
+             :lisp   lisp-xforms
+             :map    map-xforms
+             :events map-xforms)))))
 
 (defn parse-part
   "Parses the events of a single call to an instrument part."
@@ -149,94 +152,100 @@
        part-parser
        check-for-failure
        (insta/transform
-         (merge name-transforms
-                number-transforms
-                (case mode
-                  :lisp
-                  {:events          #(list* %&)
-                   :repeat          (fn [event n]
-                                      (list 'alda.lisp/times n event))
-                   :event-sequence  #(vec (list* %&))
-                   :cram            #(list* 'alda.lisp/cram %&)
-                   :voices          #(list* 'alda.lisp/voices %&)
-                   :voice           (fn [voice-number & events]
-                                      (list*
-                                        'alda.lisp/voice
-                                        voice-number
-                                        events))
-                   :voice-zero      #(list 'alda.lisp/voice 0
-                                           (list 'alda.lisp/end-voices))
-                   :tie             (constantly :tie)
-                   :slur            (constantly :slur)
-                   :flat            (constantly :flat)
-                   :sharp           (constantly :sharp)
-                   :natural         (constantly :natural)
-                   :dots            #(hash-map :dots (count %))
-                   :note-length     #(list* 'alda.lisp/note-length %&)
-                   :milliseconds    #(list 'alda.lisp/ms %)
-                   :seconds         #(list 'alda.lisp/ms (* % 1000))
-                   :duration        #(list* 'alda.lisp/duration %&)
-                   :pitch           (fn [letter & accidentals]
-                                      (list*
-                                        'alda.lisp/pitch
-                                        (keyword letter)
-                                        accidentals))
-                   :note            #(list* 'alda.lisp/note %&)
-                   :rest            #(list* 'alda.lisp/pause %&)
-                   :chord           #(list* 'alda.lisp/chord %&)
-                   :octave-set      #(list 'alda.lisp/octave %)
-                   :octave-up       #(list 'alda.lisp/octave :up)
-                   :octave-down     #(list 'alda.lisp/octave :down)
-                   :marker          #(list 'alda.lisp/marker (:name %))
-                   :at-marker       #(list 'alda.lisp/at-marker (:name %))
-                   :barline         #(list 'alda.lisp/barline)
-                   :clj-expr-cached #(get-from-cache cache %)}
+         (let [lisp-xforms
+               {:events          #(list* %&)
+                :repeat          (fn [event n]
+                                   (list 'alda.lisp/times n event))
+                :event-sequence  #(vec (list* %&))
+                :cram            #(list* 'alda.lisp/cram %&)
+                :voices          #(list* 'alda.lisp/voices %&)
+                :voice           (fn [voice-number & events]
+                                   (list*
+                                     'alda.lisp/voice
+                                     voice-number
+                                     events))
+                :voice-zero      #(list 'alda.lisp/voice 0
+                                        (list 'alda.lisp/end-voices))
+                :tie             (constantly :tie)
+                :slur            (constantly :slur)
+                :flat            (constantly :flat)
+                :sharp           (constantly :sharp)
+                :natural         (constantly :natural)
+                :dots            #(hash-map :dots (count %))
+                :note-length     #(list* 'alda.lisp/note-length %&)
+                :milliseconds    #(list 'alda.lisp/ms %)
+                :seconds         #(list 'alda.lisp/ms (* % 1000))
+                :duration        #(list* 'alda.lisp/duration %&)
+                :pitch           (fn [letter & accidentals]
+                                   (list*
+                                     'alda.lisp/pitch
+                                     (keyword letter)
+                                     accidentals))
+                :note            #(list* 'alda.lisp/note %&)
+                :rest            #(list* 'alda.lisp/pause %&)
+                :chord           #(list* 'alda.lisp/chord %&)
+                :octave-set      #(list 'alda.lisp/octave %)
+                :octave-up       #(list 'alda.lisp/octave :up)
+                :octave-down     #(list 'alda.lisp/octave :down)
+                :marker          #(list 'alda.lisp/marker (:name %))
+                :at-marker       #(list 'alda.lisp/at-marker (:name %))
+                :barline         #(list 'alda.lisp/barline)
+                :clj-expr-cached #(get-from-cache cache %)}
 
-                  :map
-                  {:events          vector
-                   :repeat          (fn [event n]
-                                      (evts/times n event))
-                   :event-sequence  vector
-                   :cram            #(apply evts/cram %&)
-                   :voices          #(apply evts/voices %&)
-                   :voice           (fn [voice-number & events]
-                                      (apply evts/voice
-                                             voice-number
-                                             events))
-                   :voice-zero      #(evts/voice 0 (evts/end-voices))
-                   :tie             (constantly :tie)
-                   :slur            (constantly :slur)
-                   :flat            (constantly :flat)
-                   :sharp           (constantly :sharp)
-                   :natural         (constantly :natural)
-                   :dots            #(hash-map :dots (count %))
-                   :note-length     #(apply dur/note-length %&)
-                   :milliseconds    #(dur/ms %)
-                   :seconds         #(dur/ms (* % 1000))
-                   :duration        #(apply dur/duration %&)
-                   :pitch           (fn [letter & accidentals]
-                                      (apply pitch/pitch
-                                             (keyword letter)
-                                             accidentals))
-                   :note            #(apply evts/note %&)
-                   :rest            #(apply evts/pause %&)
-                   :chord           #(apply evts/chord %&)
-                   :octave-set      #(attrs/octave %)
-                   :octave-up       #(attrs/octave :up)
-                   :octave-down     #(attrs/octave :down)
-                   :marker          #(evts/marker (:name %))
-                   :at-marker       #(evts/at-marker (:name %))
-                   :barline         #(evts/barline)
-                   :clj-expr-cached #(eval (get-from-cache cache %))})))))
+               map-xforms
+               {:events          vector
+                :repeat          (fn [event n]
+                                   (evts/times n event))
+                :event-sequence  vector
+                :cram            #(apply evts/cram %&)
+                :voices          #(apply evts/voices %&)
+                :voice           (fn [voice-number & events]
+                                   (apply evts/voice
+                                          voice-number
+                                          events))
+                :voice-zero      #(evts/voice 0 (evts/end-voices))
+                :tie             (constantly :tie)
+                :slur            (constantly :slur)
+                :flat            (constantly :flat)
+                :sharp           (constantly :sharp)
+                :natural         (constantly :natural)
+                :dots            #(hash-map :dots (count %))
+                :note-length     #(apply dur/note-length %&)
+                :milliseconds    #(dur/ms %)
+                :seconds         #(dur/ms (* % 1000))
+                :duration        #(apply dur/duration %&)
+                :pitch           (fn [letter & accidentals]
+                                   (apply pitch/pitch
+                                          (keyword letter)
+                                          accidentals))
+                :note            #(apply evts/note %&)
+                :rest            #(apply evts/pause %&)
+                :chord           #(apply evts/chord %&)
+                :octave-set      #(attrs/octave %)
+                :octave-up       #(attrs/octave :up)
+                :octave-down     #(attrs/octave :down)
+                :marker          #(evts/marker (:name %))
+                :at-marker       #(evts/at-marker (:name %))
+                :barline         #(evts/barline)
+                :clj-expr-cached #(eval (get-from-cache cache %))}]
+           (merge name-transforms
+                  number-transforms
+                  (case mode
+                    :lisp   lisp-xforms
+                    :map    map-xforms
+                    :events map-xforms))))))
 
 (defn parse-input
   "Parses a string of Alda code.
 
-   Is `mode` is:
+   If `mode` is:
 
-     :lisp -- the output is Clojure code using the alda.lisp DSL
-     :map  -- the output is the map of score data that would result from
-              evaluating the code (default)"
+     :lisp   -- the output is Clojure code using the alda.lisp DSL (default)
+     :map    -- the output is the map of score data that would result from
+     evaluating the code
+     :events -- the output is a vector of events, which, when supplied as the
+     arguments to alda.lisp/score, will result in the aforementioned
+     map of score data"
   [alda-code & [mode]]
   (let [mode  (or mode :lisp)
         cache (atom {})]
@@ -244,25 +253,28 @@
          remove-comments
          separate-parts
          (insta/transform
-           (case mode
-             :lisp
-             {:score  #(apply concat '(alda.lisp/score) %&)
-              :header #(parse-header mode cache (apply str %&))
-              :part   (fn [names & music-data]
-                        (list
-                          (list* 'alda.lisp/part
-                                 names
-                                 (parse-part mode
-                                             cache
-                                             (apply str music-data)))))}
+           (let [lisp-xforms
+                 {:score  #(apply concat '(alda.lisp/score) %&)
+                  :header #(parse-header mode cache (apply str %&))
+                  :part   (fn [names & music-data]
+                            (list
+                              (list* 'alda.lisp/part
+                                     names
+                                     (parse-part mode
+                                                 cache
+                                                 (apply str music-data)))))}
 
-             :map
-             {:score  #(apply score/score %&)
-              :header #(parse-header mode cache (apply str %&))
-              :part   (fn [names & music-data]
-                        (apply evts/part
-                               names
-                               (parse-part mode
-                                           cache
-                                           (apply str music-data))))})))))
+                 map-xforms
+                 {:score  #(apply score/score %&)
+                  :header #(parse-header mode cache (apply str %&))
+                  :part   (fn [names & music-data]
+                            (apply evts/part
+                                   names
+                                   (parse-part mode
+                                               cache
+                                               (apply str music-data))))}]
+             (case mode
+               :lisp   lisp-xforms
+               :map    map-xforms
+               :events (assoc map-xforms :score vector)))))))
 

--- a/server/src/alda/parser_util.clj
+++ b/server/src/alda/parser_util.clj
@@ -9,7 +9,7 @@
     (->> [alda-code cache]
          remove-comments
          ((fn [[alda-code cache]]
-            (parse-part cache alda-code))))))
+            (parse-part :lisp cache alda-code))))))
 
 (defn- test-parse-part
   [alda-code]
@@ -21,11 +21,11 @@
            {:score  #(if (> (count %&) 1)
                        (throw (Exception. "This is more than one part."))
                        (first %&))
-            :header #(parse-header cache (apply str %&))
+            :header #(parse-header :lisp cache (apply str %&))
             :part   (fn [names & music-data]
                       (list* 'alda.lisp/part
                              names
-                             (parse-part cache (apply str music-data))))}))))
+                             (parse-part :lisp cache (apply str music-data))))}))))
 
 (defn- test-parse-calls
   [alda-code]

--- a/server/src/alda/parser_util.clj
+++ b/server/src/alda/parser_util.clj
@@ -86,3 +86,7 @@
 (defn parse-to-map-with-context
   [& args]
   (apply parse-with-context :map args))
+
+(defn parse-to-events-with-context
+  [& args]
+  (apply parse-with-context :events args))

--- a/server/src/alda/repl/core.clj
+++ b/server/src/alda/repl/core.clj
@@ -1,12 +1,12 @@
 (ns alda.repl.core
-  (:require [instaparse.core :as    insta]
-            [taoensso.timbre :as    log]
-            [clojure.java.io :as    io]
-            [clojure.string  :as    str]
-            [alda.parser     :refer (parse-input)]
-            [alda.parser-util]
-            [alda.lisp       :refer :all]
-            [alda.now        :as    now])
+  (:require [instaparse.core  :as    insta]
+            [taoensso.timbre  :as    log]
+            [clojure.java.io  :as    io]
+            [clojure.string   :as    str]
+            [alda.parser      :refer (parse-input)]
+            [alda.parser-util :as    p-util]
+            [alda.lisp        :refer :all]
+            [alda.now         :as    now])
   (:import [jline.console ConsoleReader]))
 
 (def ^:dynamic *repl-reader* (doto (ConsoleReader.)
@@ -39,7 +39,7 @@
 
 (defn load-score!
   [score-text]
-  (let [loaded-score (-> score-text parse-input eval new-repl-score)]
+  (let [loaded-score (-> score-text (parse-input :map) new-repl-score)]
     (alter-var-root #'*current-score* (constantly loaded-score))
     (swap! *current-score* assoc :score-text score-text)))
 
@@ -50,7 +50,7 @@
    Sets the :parsing-context of the score or logs an error, depending on the
    outcome of the parse attempt."
   [alda-code]
-  (let [[context parse-result] (alda.parser-util/parse-with-context alda-code)]
+  (let [[context parse-result] (p-util/parse-to-lisp-with-context alda-code)]
     (if (= context :parse-failure)
       (log/error "Invalid Alda syntax.")
       (do

--- a/server/src/alda/server.clj
+++ b/server/src/alda/server.clj
@@ -169,11 +169,8 @@
   [code & {:keys [mode] :or {mode :lisp}}]
   (try
     (require '[alda.lisp :refer :all])
-    (let [parse-result (parse-input code)]
-      (edn-response (case mode
-                      :lisp   "TODO"
-                      :events parse-result
-                      :map    (apply score parse-result))))
+    (let [parse-result (parse-input code mode)]
+      (edn-response parse-result))
     (catch Throwable e
       (log/error e e)
       (server-error (.getMessage e)))))

--- a/server/src/alda/server.clj
+++ b/server/src/alda/server.clj
@@ -2,7 +2,7 @@
   (:require [alda.lisp                        :refer :all]
             [alda.now                         :as    now]
             [alda.parser                      :refer (parse-input)]
-            [alda.parser-util                 :refer (parse-with-context)]
+            [alda.parser-util                 :refer (parse-to-map-with-context)]
             [alda.sound                       :refer (*play-opts*)]
             [alda.sound.midi                  :as    midi]
             [alda.util]
@@ -129,7 +129,7 @@
                   ]}]
   (try
     (require '[alda.lisp :refer :all])
-    (let [[context parse-result] (parse-with-context code)]
+    (let [[context parse-result] (parse-to-map-with-context code)]
       (cond
         (and (or replace-score?
                  one-off?

--- a/server/src/alda/server.clj
+++ b/server/src/alda/server.clj
@@ -171,8 +171,9 @@
     (require '[alda.lisp :refer :all])
     (let [parse-result (parse-input code)]
       (edn-response (case mode
-                      :lisp parse-result
-                      :map (eval parse-result))))
+                      :lisp   "TODO"
+                      :events parse-result
+                      :map    (apply score parse-result))))
     (catch Throwable e
       (log/error e e)
       (server-error (.getMessage e)))))

--- a/server/src/alda/server.clj
+++ b/server/src/alda/server.clj
@@ -2,7 +2,7 @@
   (:require [alda.lisp                        :refer :all]
             [alda.now                         :as    now]
             [alda.parser                      :refer (parse-input)]
-            [alda.parser-util                 :refer (parse-to-map-with-context)]
+            [alda.parser-util                 :refer (parse-to-events-with-context)]
             [alda.sound                       :refer (*play-opts*)]
             [alda.sound.midi                  :as    midi]
             [alda.util]
@@ -129,7 +129,7 @@
                   ]}]
   (try
     (require '[alda.lisp :refer :all])
-    (let [[context parse-result] (parse-to-map-with-context code)]
+    (let [[context events] (parse-to-events-with-context code)]
       (cond
         (and (or replace-score?
                  one-off?
@@ -148,18 +148,12 @@
             (new-score!))
           (when-not one-off?
             (score-text<< code))
-          (let [events (-> (case context
-                             :music-data (vec parse-result)
-                             :part       parse-result
-                             :score      (vec (rest parse-result))
-                             parse-result)
-                           eval)]
-            (cond
-              one-off? (now/with-new-score
-                         (now/play! events))
-              silent?  (swap! *current-score* continue events)
-              :else    (now/with-score *current-score*
-                         (now/play! events))))
+          (cond
+            one-off? (now/with-new-score
+                       (now/play! events))
+            silent?  (swap! *current-score* continue events)
+            :else    (now/with-score *current-score*
+                       (now/play! events)))
           (success "OK"))))
     (catch Throwable e
       (log/error e e)

--- a/server/test/alda/examples_test.clj
+++ b/server/test/alda/examples_test.clj
@@ -57,33 +57,20 @@
 (deftest examples-test
   (require '[alda.lisp :refer :all])
   (testing "example scores:"
-    (doseq [score example-scores]
-      (let [parse-result (atom nil)]
-        (testing (str "parsing " score ".alda")
-          (printf "Parsing    %s.alda... %s" score (spacing score)) (flush)
+    (doseq [score example-scores
+            [mode desc] [[:lisp "code"] [:map "data"]]]
+      (let [score-text (-> (str score ".alda")
+                           io/resource
+                           io/file
+                           slurp)]
+        (testing (format "parsing (as %s) %s.alda" desc score)
+          (printf "Parsing (as %s) %s.alda... %s" desc score (spacing score))
+          (flush)
           (is
             (try
-              (let [score-text (-> (str score ".alda")
-                                   io/resource
-                                   io/file
-                                   slurp)
-                    [result time-ms] (time+ (parse-input score-text))]
+              (let [[result time-ms] (time+ (parse-input score-text mode))]
                 (println (green "OK") (format "(%s ms)" time-ms))
-                (reset! parse-result result)
                 true)
               (catch Exception e
                 (println (red "FAIL"))
-                (throw e)))))
-        (when @parse-result
-          (testing (str "evaluating " score ".alda")
-            (printf "Evaluating %s.alda... %s" score (spacing score)) (flush)
-            (is
-              (try
-                (let [[result time-ms] (time+ (eval @parse-result))]
-                  (println (green "OK") (format "(%s ms)" time-ms))
-                  true)
-                (catch Exception e
-                  (println (red "FAIL"))
-                  (throw e))
-                (finally
-                  (reset! parse-result nil))))))))))
+                (throw e)))))))))

--- a/server/test/alda/lisp/code_test.clj
+++ b/server/test/alda/lisp/code_test.clj
@@ -1,0 +1,24 @@
+(ns alda.lisp.code-test
+  (:require [clojure.test :refer :all]
+            [alda.lisp    :refer :all]))
+
+(deftest code-tests
+  (testing "the alda-code function:"
+    (let [s      (score
+                   (part "piano"
+                     (alda-code "c d e")))
+          events (:events s)]
+      (testing "should parse events out of a string of alda code and splice
+                them into the score"
+        (is (= 3 (count events)))
+        (is (= #{60 62 64} (set (map :midi-note events))))))
+    (let [s      (score
+                   (alda-code "piano:    c d e
+                               clarinet: f g a"))
+          events      (:events s)
+          instruments (:instruments s)]
+      (testing "should parse events out of a string of alda code and splice
+                them into the score"
+        (is (= 2 (count instruments)))
+        (is (= 6 (count events)))
+        (is (= #{60 62 64 65 67 69} (set (map :midi-note events))))))))

--- a/server/test/alda/lisp/duration_test.clj
+++ b/server/test/alda/lisp/duration_test.clj
@@ -59,7 +59,7 @@
   (testing "slurred notes ignore quantization"
     (let [s      (score
                    (part "piano" (tempo 120) (quant 90)
-                     (note (pitch :c) (duration (note-length 4) :slur))))
+                     (note (pitch :c) (duration (note-length 4)) :slur)))
           piano  (get-instrument s "piano")
           events (:events s)]
       (is (== 500 (:duration (first events)))))

--- a/server/test/alda/lisp/notes_test.clj
+++ b/server/test/alda/lisp/notes_test.clj
@@ -10,7 +10,7 @@
           start (:current-offset piano)
           c     ((pitch :c) (:octave piano) (:key-signature piano))
           s     (continue s
-                  (note (pitch :c) (duration (note-length 4) :slur)))
+                  (note (pitch :c) (duration (note-length 4)) :slur))
           piano (get-instrument s "piano")
           {:keys [duration offset pitch] :as note} (first (:events s))]
       (testing "should be placed at the current offset"

--- a/server/test/alda/parser/barlines_test.clj
+++ b/server/test/alda/parser/barlines_test.clj
@@ -1,6 +1,6 @@
 (ns alda.parser.barlines-test
   (:require [clojure.test :refer :all]
-            [alda.parser-util :refer (parse-with-context)]))
+            [alda.parser-util :refer (parse-to-lisp-with-context)]))
 
 (def alda-code-1
   "violin: c d | e f | g a")
@@ -40,7 +40,7 @@
 
 (deftest barline-tests
   (testing "barlines are included in alda.lisp code (even though they don't do anything)"
-    (is (= alda-lisp-code-1 (parse-with-context :score alda-code-1))))
+    (is (= alda-lisp-code-1 (parse-to-lisp-with-context :score alda-code-1))))
   (testing "notes can be tied over barlines"
-    (is (= alda-lisp-code-2 (parse-with-context :score alda-code-2)))))
+    (is (= alda-lisp-code-2 (parse-to-lisp-with-context :score alda-code-2)))))
 

--- a/server/test/alda/parser/clj_exprs_test.clj
+++ b/server/test/alda/parser/clj_exprs_test.clj
@@ -1,86 +1,86 @@
 (ns alda.parser.clj-exprs-test
-  (:require [clojure.test      :refer :all]
-            [alda.parser-util :refer (parse-with-context)]))
+  (:require [clojure.test     :refer :all]
+            [alda.parser-util :refer (parse-to-lisp-with-context)]))
 
 (deftest attribute-tests
   (testing "volume change"
-    (is (= (parse-with-context :music-data "(volume 50)") '((volume 50)))))
+    (is (= (parse-to-lisp-with-context :music-data "(volume 50)") '((volume 50)))))
   (testing "tempo change"
-    (is (= (parse-with-context :music-data "(tempo 100)") '((tempo 100)))))
+    (is (= (parse-to-lisp-with-context :music-data "(tempo 100)") '((tempo 100)))))
   (testing "quantization change"
-    (is (= (parse-with-context :music-data "(quant 75)") '((quant 75)))))
+    (is (= (parse-to-lisp-with-context :music-data "(quant 75)") '((quant 75)))))
   (testing "panning change"
-    (is (= (parse-with-context :music-data "(panning 0)") '((panning 0))))))
+    (is (= (parse-to-lisp-with-context :music-data "(panning 0)") '((panning 0))))))
 
 (deftest multiple-attribute-change-tests
   (testing "attribute changes"
-    (is (= (parse-with-context :music-data "(do (vol 50) (tempo 100))")
+    (is (= (parse-to-lisp-with-context :music-data "(do (vol 50) (tempo 100))")
            '((do (vol 50) (tempo 100)))))
-    (is (= (parse-with-context :music-data "(do (quant! 50) (tempo 90))")
+    (is (= (parse-to-lisp-with-context :music-data "(do (quant! 50) (tempo 90))")
            '((do (quant! 50) (tempo 90))))))
   (testing "global attribute changes"
-    (is (= (parse-with-context :music-data "(tempo! 126)")
+    (is (= (parse-to-lisp-with-context :music-data "(tempo! 126)")
            '((tempo! 126))))
-    (is (= (parse-with-context :music-data "(do (tempo! 130) (quant! 80))")
+    (is (= (parse-to-lisp-with-context :music-data "(do (tempo! 130) (quant! 80))")
            '((do (tempo! 130) (quant! 80)))))))
 
 (deftest comma-and-semicolon-tests
   (testing "commas/semicolons can exist in strings"
-    (is (= (parse-with-context :music-data "(println \"hi; hi, hi\")")
+    (is (= (parse-to-lisp-with-context :music-data "(println \"hi; hi, hi\")")
            '((println "hi; hi, hi")))))
   (testing "commas inside [brackets] and {braces} won't break things"
-    (is (= (parse-with-context :music-data "(prn [1,2,3])")
+    (is (= (parse-to-lisp-with-context :music-data "(prn [1,2,3])")
            '((prn [1 2 3]))))
-    (is (= (parse-with-context :music-data "(prn {:a 1, :b 2})")
+    (is (= (parse-to-lisp-with-context :music-data "(prn {:a 1, :b 2})")
            '((prn {:a 1 :b 2})))))
   (testing "comma/semicolon character literals are OK too"
-    (is (= (parse-with-context :music-data "(println \\, \\;)")
+    (is (= (parse-to-lisp-with-context :music-data "(println \\, \\;)")
            '((println \, \;))))))
 
 (deftest paren-tests
   (testing "parens inside of a string are NOT a clj-expr"
-    (is (= (parse-with-context :music-data "(prn \"a string (with parens)\")")
+    (is (= (parse-to-lisp-with-context :music-data "(prn \"a string (with parens)\")")
            '((prn "a string (with parens)"))))
-    (is (= (parse-with-context :music-data "(prn \"a string with just a closing paren)\")")
+    (is (= (parse-to-lisp-with-context :music-data "(prn \"a string with just a closing paren)\")")
            '((prn "a string with just a closing paren)")))))
   (testing "paren character literals don't break things"
-    (is (= (parse-with-context :music-data "(prn \\()")
+    (is (= (parse-to-lisp-with-context :music-data "(prn \\()")
            '((prn \())))
-    (is (= (parse-with-context :music-data "(prn \\))")
+    (is (= (parse-to-lisp-with-context :music-data "(prn \\))")
            '((prn \)))))
-    (is (= (parse-with-context :music-data "(prn \\( (+ 1 1) \\))")
+    (is (= (parse-to-lisp-with-context :music-data "(prn \\( (+ 1 1) \\))")
            '((prn \( (+ 1 1) \)))))))
 
 (deftest vector-tests
   (testing "vectors are a thing"
-    (is (= (parse-with-context :music-data "(prn [1 2 3 \\a :b \"c\"])")
+    (is (= (parse-to-lisp-with-context :music-data "(prn [1 2 3 \\a :b \"c\"])")
            '((prn [1 2 3 \a :b "c"])))))
   (testing "vectors can have commas in them"
-    (is (= (parse-with-context :music-data "(prn [1, 2, 3])")
+    (is (= (parse-to-lisp-with-context :music-data "(prn [1, 2, 3])")
            '((prn [1 2 3]))))))
 
 (deftest map-tests
   (testing "maps are a thing"
-    (is (= (parse-with-context :music-data "(prn {:a 1 :b 2 :c 3})")
+    (is (= (parse-to-lisp-with-context :music-data "(prn {:a 1 :b 2 :c 3})")
            '((prn {:a 1 :b 2 :c 3})))))
   (testing "maps can have commas in them"
-    (is (= (parse-with-context :music-data "(prn {:a 1, :b 2, :c 3})")
+    (is (= (parse-to-lisp-with-context :music-data "(prn {:a 1, :b 2, :c 3})")
            '((prn {:a 1 :b 2 :c 3}))))))
 
 (deftest set-tests
   (testing "sets are a thing"
-    (is (= (parse-with-context :music-data "(prn #{1 2 3})")
+    (is (= (parse-to-lisp-with-context :music-data "(prn #{1 2 3})")
            '((prn #{1 2 3})))))
   (testing "sets can have commas in them"
-    (is (= (parse-with-context :music-data "(prn #{1, 2, 3})")
+    (is (= (parse-to-lisp-with-context :music-data "(prn #{1, 2, 3})")
            '((prn #{1 2 3}))))))
 
 (deftest nesting-things
   (testing "things can be nested and it won't break shit"
-    (is (= (parse-with-context :music-data "(prn [1 2 [3 4] 5])")
+    (is (= (parse-to-lisp-with-context :music-data "(prn [1 2 [3 4] 5])")
            '((prn [1 2 [3 4] 5]))))
-    (is (= (parse-with-context :music-data "(prn #{1 2 #{3 4} 5})")
+    (is (= (parse-to-lisp-with-context :music-data "(prn #{1 2 #{3 4} 5})")
            '((prn #{1 2 #{3 4} 5}))))
-    (is (= (parse-with-context :music-data "(prn (+ 1 [2 {3 #{4 5}}]))")
+    (is (= (parse-to-lisp-with-context :music-data "(prn (+ 1 [2 {3 #{4 5}}]))")
            '((prn (+ 1 [2 {3 #{4 5}}])))))))
 

--- a/server/test/alda/parser/duration_test.clj
+++ b/server/test/alda/parser/duration_test.clj
@@ -1,31 +1,31 @@
 (ns alda.parser.duration-test
   (:require [clojure.test :refer :all]
-            [alda.parser-util :refer (parse-with-context)]))
+            [alda.parser-util :refer (parse-to-lisp-with-context)]))
 
 (deftest duration-tests
   (testing "duration"
-    (is (= (parse-with-context :music-data "c2")
+    (is (= (parse-to-lisp-with-context :music-data "c2")
            '((alda.lisp/note
                (alda.lisp/pitch :c)
                (alda.lisp/duration (alda.lisp/note-length 2))))))))
 
 (deftest dot-tests
   (testing "dots"
-    (is (= (parse-with-context :music-data "c2..")
+    (is (= (parse-to-lisp-with-context :music-data "c2..")
            '((alda.lisp/note
                (alda.lisp/pitch :c)
                (alda.lisp/duration (alda.lisp/note-length 2 {:dots 2}))))))))
 
 (deftest millisecond-duration-tests
   (testing "duration in milliseconds"
-    (is (= (parse-with-context :music-data "c450ms")
+    (is (= (parse-to-lisp-with-context :music-data "c450ms")
            '((alda.lisp/note
                (alda.lisp/pitch :c)
                (alda.lisp/duration (alda.lisp/ms 450))))))))
 
 (deftest second-duration-tests
   (testing "duration in seconds"
-    (is (= (parse-with-context :music-data "c2s")
+    (is (= (parse-to-lisp-with-context :music-data "c2s")
            '((alda.lisp/note
                (alda.lisp/pitch :c)
                (alda.lisp/duration (alda.lisp/ms 2000))))))))
@@ -33,30 +33,30 @@
 (deftest tie-and-slur-tests
   (testing "ties"
     (testing "ties"
-      (is (= (parse-with-context :music-data "c1~2~4")
+      (is (= (parse-to-lisp-with-context :music-data "c1~2~4")
              '((alda.lisp/note
                  (alda.lisp/pitch :c)
                  (alda.lisp/duration (alda.lisp/note-length 1)
                                      (alda.lisp/note-length 2)
                                      (alda.lisp/note-length 4))))))
-      (is (= (parse-with-context :music-data "c500ms~350ms")
+      (is (= (parse-to-lisp-with-context :music-data "c500ms~350ms")
              '((alda.lisp/note
                  (alda.lisp/pitch :c)
                  (alda.lisp/duration (alda.lisp/ms 500)
                                      (alda.lisp/ms 350))))))
-      (is (= (parse-with-context :music-data "c5s~4~350ms")
+      (is (= (parse-to-lisp-with-context :music-data "c5s~4~350ms")
              '((alda.lisp/note
                  (alda.lisp/pitch :c)
                  (alda.lisp/duration (alda.lisp/ms 5000)
                                      (alda.lisp/note-length 4)
                                      (alda.lisp/ms 350)))))))
     (testing "slurs"
-      (is (= (parse-with-context :music-data "c4~")
+      (is (= (parse-to-lisp-with-context :music-data "c4~")
              '((alda.lisp/note
                  (alda.lisp/pitch :c)
                  (alda.lisp/duration (alda.lisp/note-length 4))
                  :slur))))
-      (is (= (parse-with-context :music-data "c420ms~")
+      (is (= (parse-to-lisp-with-context :music-data "c420ms~")
              '((alda.lisp/note
                  (alda.lisp/pitch :c)
                  (alda.lisp/duration (alda.lisp/ms 420))

--- a/server/test/alda/parser/event_sequences_test.clj
+++ b/server/test/alda/parser/event_sequences_test.clj
@@ -1,10 +1,10 @@
 (ns alda.parser.event-sequences-test
   (:require [clojure.test :refer :all]
-            [alda.parser-util :refer (parse-with-context)]))
+            [alda.parser-util :refer (parse-to-lisp-with-context)]))
 
 (deftest event-sequence-tests
   (testing "event sequences"
-    (is (= (parse-with-context :music-data "[ c d e f c/e/g ]")
+    (is (= (parse-to-lisp-with-context :music-data "[ c d e f c/e/g ]")
            '([(alda.lisp/note (alda.lisp/pitch :c))
               (alda.lisp/note (alda.lisp/pitch :d))
               (alda.lisp/note (alda.lisp/pitch :e))
@@ -13,7 +13,7 @@
                 (alda.lisp/note (alda.lisp/pitch :c))
                 (alda.lisp/note (alda.lisp/pitch :e))
                 (alda.lisp/note (alda.lisp/pitch :g)))])))
-    (is (= (parse-with-context :music-data "[c d [e f] g]")
+    (is (= (parse-to-lisp-with-context :music-data "[c d [e f] g]")
            '([(alda.lisp/note (alda.lisp/pitch :c))
               (alda.lisp/note (alda.lisp/pitch :d))
               [(alda.lisp/note (alda.lisp/pitch :e))

--- a/server/test/alda/parser/events_test.clj
+++ b/server/test/alda/parser/events_test.clj
@@ -1,32 +1,32 @@
 (ns alda.parser.events-test
   (:require [clojure.test :refer :all]
-            [alda.parser-util :refer (parse-with-context)]))
+            [alda.parser-util :refer (parse-to-lisp-with-context)]))
 
 (deftest note-tests
   (testing "notes"
-    (is (= (parse-with-context :music-data "c")
+    (is (= (parse-to-lisp-with-context :music-data "c")
            '((alda.lisp/note (alda.lisp/pitch :c)))))
-    (is (= (parse-with-context :music-data "c4")
+    (is (= (parse-to-lisp-with-context :music-data "c4")
            '((alda.lisp/note (alda.lisp/pitch :c)
                              (alda.lisp/duration (alda.lisp/note-length 4))))))
-    (is (= (parse-with-context :music-data "c+")
+    (is (= (parse-to-lisp-with-context :music-data "c+")
            '((alda.lisp/note (alda.lisp/pitch :c :sharp)))))
-    (is (= (parse-with-context :music-data "b-")
+    (is (= (parse-to-lisp-with-context :music-data "b-")
            '((alda.lisp/note (alda.lisp/pitch :b :flat))))))
   (testing "rests"
-    (is (= (parse-with-context :music-data "r")
+    (is (= (parse-to-lisp-with-context :music-data "r")
            '((alda.lisp/pause)))
-        (= (parse-with-context :music-data "r1")
+        (= (parse-to-lisp-with-context :music-data "r1")
            '((alda.lisp/pause (alda.lisp/duration (alda.lisp/note-length 1))))))))
 
 (deftest chord-tests
   (testing "chords"
-    (is (= (parse-with-context :music-data "c/e/g")
+    (is (= (parse-to-lisp-with-context :music-data "c/e/g")
            '((alda.lisp/chord
               (alda.lisp/note (alda.lisp/pitch :c))
               (alda.lisp/note (alda.lisp/pitch :e))
               (alda.lisp/note (alda.lisp/pitch :g))))))
-    (is (= (parse-with-context :music-data "c1/>e2/g4/r8")
+    (is (= (parse-to-lisp-with-context :music-data "c1/>e2/g4/r8")
            '((alda.lisp/chord
                (alda.lisp/note (alda.lisp/pitch :c)
                                (alda.lisp/duration (alda.lisp/note-length 1)))
@@ -36,7 +36,7 @@
                (alda.lisp/note (alda.lisp/pitch :g)
                                (alda.lisp/duration (alda.lisp/note-length 4)))
                (alda.lisp/pause (alda.lisp/duration (alda.lisp/note-length 8)))))))
-    (is (= (parse-with-context :music-data "b>/d/f2.")
+    (is (= (parse-to-lisp-with-context :music-data "b>/d/f2.")
            '((alda.lisp/chord
                (alda.lisp/note (alda.lisp/pitch :b))
                (alda.lisp/octave :up)
@@ -46,14 +46,14 @@
 
 (deftest voice-tests
   (testing "voices"
-    (is (= (parse-with-context :part "piano: V1: a b c")
+    (is (= (parse-to-lisp-with-context :part "piano: V1: a b c")
            '(alda.lisp/part {:names ["piano"]}
               (alda.lisp/voices
                 (alda.lisp/voice 1
                   (alda.lisp/note (alda.lisp/pitch :a))
                   (alda.lisp/note (alda.lisp/pitch :b))
                   (alda.lisp/note (alda.lisp/pitch :c)))))))
-    (is (= (parse-with-context :part "piano:
+    (is (= (parse-to-lisp-with-context :part "piano:
                                         V1: a b c
                                         V2: d e f")
            '(alda.lisp/part {:names ["piano"]}
@@ -66,7 +66,7 @@
                   (alda.lisp/note (alda.lisp/pitch :d))
                   (alda.lisp/note (alda.lisp/pitch :e))
                   (alda.lisp/note (alda.lisp/pitch :f)))))))
-    (is (= (parse-with-context :part "piano:
+    (is (= (parse-to-lisp-with-context :part "piano:
                                         V1: a b c | V2: d e f")
            '(alda.lisp/part {:names ["piano"]}
               (alda.lisp/voices
@@ -79,7 +79,7 @@
                   (alda.lisp/note (alda.lisp/pitch :d))
                   (alda.lisp/note (alda.lisp/pitch :e))
                   (alda.lisp/note (alda.lisp/pitch :f)))))))
-    (is (= (parse-with-context :part "piano:
+    (is (= (parse-to-lisp-with-context :part "piano:
                                         V1: [a b c] *8
                                         V2: [d e f] *8")
            '(alda.lisp/part {:names ["piano"]}
@@ -97,19 +97,19 @@
 
 (deftest marker-tests
   (testing "markers"
-    (is (= (parse-with-context :music-data "%chorus")
+    (is (= (parse-to-lisp-with-context :music-data "%chorus")
            '((alda.lisp/marker "chorus"))))
-    (is (= (parse-with-context :music-data "@verse-1")
+    (is (= (parse-to-lisp-with-context :music-data "@verse-1")
            '((alda.lisp/at-marker "verse-1"))))))
 
 (deftest cram-tests
   (testing "crams"
-    (is (= (parse-with-context :music-data "{c d e}")
+    (is (= (parse-to-lisp-with-context :music-data "{c d e}")
            '((alda.lisp/cram
                (alda.lisp/note (alda.lisp/pitch :c))
                (alda.lisp/note (alda.lisp/pitch :d))
                (alda.lisp/note (alda.lisp/pitch :e))))))
-    (is (= (parse-with-context :music-data "{c d e}2")
+    (is (= (parse-to-lisp-with-context :music-data "{c d e}2")
            '((alda.lisp/cram
                (alda.lisp/note (alda.lisp/pitch :c))
                (alda.lisp/note (alda.lisp/pitch :d))

--- a/server/test/alda/parser/octaves_test.clj
+++ b/server/test/alda/parser/octaves_test.clj
@@ -1,13 +1,13 @@
 (ns alda.parser.octaves-test
   (:require [clojure.test :refer :all]
-            [alda.parser-util :refer (parse-with-context)]))
+            [alda.parser-util :refer (parse-to-lisp-with-context)]))
 
 (deftest octave-tests
   (testing "octave change"
     (is (= '((alda.lisp/octave :up))
-           (parse-with-context :music-data ">")))
+           (parse-to-lisp-with-context :music-data ">")))
     (is (= '((alda.lisp/octave :down))
-           (parse-with-context :music-data "<")))
+           (parse-to-lisp-with-context :music-data "<")))
     (is (= '((alda.lisp/octave 5))
-           (parse-with-context :music-data "o5")))))
+           (parse-to-lisp-with-context :music-data "o5")))))
 

--- a/server/test/alda/parser/repeats_test.clj
+++ b/server/test/alda/parser/repeats_test.clj
@@ -1,33 +1,33 @@
 (ns alda.parser.repeats-test
-  (:require [clojure.test      :refer :all]
-            [alda.parser-util :refer (parse-with-context)]))
+  (:require [clojure.test     :refer :all]
+            [alda.parser-util :refer (parse-to-lisp-with-context)]))
 
 (deftest repeat-tests
   (testing "repeated events"
-    (is (= (parse-with-context :music-data "[c d e] *4")
+    (is (= (parse-to-lisp-with-context :music-data "[c d e] *4")
            '((alda.lisp/times 4
                [(alda.lisp/note (alda.lisp/pitch :c))
                 (alda.lisp/note (alda.lisp/pitch :d))
                 (alda.lisp/note (alda.lisp/pitch :e))]))))
-    (is (= (parse-with-context :music-data "[ c > ]*5")
+    (is (= (parse-to-lisp-with-context :music-data "[ c > ]*5")
            '((alda.lisp/times 5
                [(alda.lisp/note (alda.lisp/pitch :c))
                 (alda.lisp/octave :up)]))))
-    (is (= (parse-with-context :music-data "[ c > ] * 5")
+    (is (= (parse-to-lisp-with-context :music-data "[ c > ] * 5")
            '((alda.lisp/times 5
                [(alda.lisp/note (alda.lisp/pitch :c))
                 (alda.lisp/octave :up)]))))
-    (is (= (parse-with-context :music-data "c8*7")
+    (is (= (parse-to-lisp-with-context :music-data "c8*7")
            '((alda.lisp/times 7
                (alda.lisp/note
                  (alda.lisp/pitch :c)
                  (alda.lisp/duration (alda.lisp/note-length 8)))))))
-    (is (= (parse-with-context :music-data "c8 *7")
+    (is (= (parse-to-lisp-with-context :music-data "c8 *7")
            '((alda.lisp/times 7
                (alda.lisp/note
                  (alda.lisp/pitch :c)
                  (alda.lisp/duration (alda.lisp/note-length 8)))))))
-    (is (= (parse-with-context :music-data "c8 * 7")
+    (is (= (parse-to-lisp-with-context :music-data "c8 * 7")
            '((alda.lisp/times 7
                (alda.lisp/note
                  (alda.lisp/pitch :c)


### PR DESCRIPTION
Closes #235, #238. Also helps with #208.

1. Parser optimizations by myself and @aengelberg -- for details, see #238.
2. Whereas before, to play an Alda score we fed the text to the parser, which transformed it into Clojure code and then evaluated it (leading to the "Method code too large!" error if too much code was generated), this PR makes it so that the parser transforms the Alda score text directly into the score map that would result from evaluating the Clojure code. So essentially we're skipping a step. Which is weird, because it takes slightly longer when we skip the `eval` step. I guess `eval` must be optimized in some way. Hmm. Anyway, the difference is negligible -- I'll post some benchmarks below -- and it's still significantly faster than the current release, thanks to the parser optimizations.