### PR TITLE
[WIP] Adding direct MIDI output

### DIFF
--- a/server/src/alda/now.clj
+++ b/server/src/alda/now.clj
@@ -93,8 +93,9 @@
    evaluating alda.lisp code, e.g. (score (part 'piano' (note (pitch :c)))),
    or an atom referencing such a map."
   [score & [play-opts]]
-  (sound/with-play-opts (merge {:async? true} play-opts)
-    (sound/play! (if (instance? clojure.lang.Atom score)
-                   @score
-                   score))))
+  (println "testing alda dev setup"))
+  ;(sound/with-play-opts (merge {:async? true} play-opts)
+  ;  (sound/play! (if (instance? clojure.lang.Atom score)
+  ;                 @score
+  ;                 score))))
 


### PR DESCRIPTION
From https://github.com/alda-lang/alda/issues/259.

> While there are some excellent soundfonts out there [...] nothing can beat using your own DAW, VSTs or physical devices for output.
> 
> This feature would also give us MIDI file saving, in a round about way ("record" alda into any DAW, then save the midi to file from there)

Currently a work in progress, most likely only of interest to @0atman, @daveyarwood and, potentially, nobody! Watch this space...
