### PR TITLE
#269 Use G1 and add basic memory limits

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -54,7 +54,7 @@
       (format "%s.999" n)
       version)))
 
-(def jvm-opts #{"-XX:+UseG1GC -XX:MaxGCPauseMillis=100 -Xms256m -Xmx1024m -Dclojure.compiler.direct-linking=true"})
+(def jvm-opts #{"-XX:+UseG1GC" "-XX:MaxGCPauseMillis=100" "-Xms256m" "-Xmx1024m" "-Dclojure.compiler.direct-linking=true"})
 
 (task-options!
   javac   {:options (let [jdk7-bootclasspath (System/getenv "JDK7_BOOTCLASSPATH")]

--- a/build.boot
+++ b/build.boot
@@ -54,7 +54,7 @@
       (format "%s.999" n)
       version)))
 
-(def jvm-opts #{"-Dclojure.compiler.direct-linking=true"})
+(def jvm-opts #{"-XX:+UseG1GC -XX:MaxGCPauseMillis=100 -Xms256m -Xmx1024m -Dclojure.compiler.direct-linking=true"})
 
 (task-options!
   javac   {:options (let [jdk7-bootclasspath (System/getenv "JDK7_BOOTCLASSPATH")]


### PR DESCRIPTION
Empirically G1 was found to put the least load on the system on the three boxes tested.
Memory usage between 250m and 800m.
CPU usage hovers around 9% of one core on my test machines VS 30 with previous values.