### PR TITLE
255: Implicit Voice Group Closing

### DIFF
--- a/server/grammar/voices.bnf
+++ b/server/grammar/voices.bnf
@@ -1,4 +1,4 @@
-voices       = voice (<ows> voice)* (<ows> (voice-zero | <#"\z">))
+voices       = voice (<ows> voice)* (<ows> (voice-zero | <#"\z"> | &<"]">))
 voice        = voice-number <ows> events-inside-voice
 voice-number = <"V"> #"[1-9]\d*" <":">
 voice-zero = <"V0:">

--- a/server/src/alda/lisp/events/sequence.clj
+++ b/server/src/alda/lisp/events/sequence.clj
@@ -12,5 +12,5 @@
 
 (defmethod update-score :event-sequence
   [score events]
-  (reduce update-score score events))
+  (reduce update-score score (conj events {:event-type :end-voice-group})))
 

--- a/server/src/alda/lisp/events/sequence.clj
+++ b/server/src/alda/lisp/events/sequence.clj
@@ -12,5 +12,5 @@
 
 (defmethod update-score :event-sequence
   [score events]
-  (reduce update-score score (conj events {:event-type :end-voice-group})))
+  (reduce update-score score events))
 

--- a/server/src/alda/lisp/events/voice.clj
+++ b/server/src/alda/lisp/events/voice.clj
@@ -35,7 +35,9 @@
 
 (defmethod update-score :voice-group
   [score {:keys [voices] :as voice-group}]
-  (let [score  (assoc score :voice-instruments {})]
+  (let [score (-> score 
+                  (end-voice-group) 
+                  (assoc :voice-instruments {}))]
     (reduce update-score score voices)))
 
 (defmethod update-score :end-voice-group

--- a/server/src/alda/lisp/events/voice.clj
+++ b/server/src/alda/lisp/events/voice.clj
@@ -35,10 +35,7 @@
 
 (defmethod update-score :voice-group
   [score {:keys [voices] :as voice-group}]
-  (let [score (-> score 
-                  (end-voice-group) 
-                  (assoc :voice-instruments {}))]
-    (reduce update-score score voices)))
+  (reduce update-score score voices))
 
 (defmethod update-score :end-voice-group
   [score _]

--- a/server/test/alda/lisp/voices_test.clj
+++ b/server/test/alda/lisp/voices_test.clj
@@ -71,5 +71,15 @@
                     (octave :down)
                     (note (pitch :b))
                     (note (pitch :a))
-                    (note (pitch :g)))))))))))
+                    (note (pitch :g))))))))))
+  (testing "an unclosed voice group"
+    (testing "implicitly closes at the end of a set-variable"
+      (let [{:keys [voice-instruments]} (score (set-variable :foo (voices (voice 1 (note (pitch :a))))))]
+        (is (nil? voice-instruments))))
+    (testing "implicitly closes at the end of a sequence"
+      (let [{:keys [voice-instruments]} (score [(voices (voice 1 (note (pitch :a))))])]
+        (is (nil? voice-instruments))))
+    (testing "does not implicitly close alone"
+      (let [{:keys [voice-instruments]} (score (voices (voice 1 (note (pitch :a)))))]
+        (is (some? voice-instruments))))))
 

--- a/server/test/alda/lisp/voices_test.clj
+++ b/server/test/alda/lisp/voices_test.clj
@@ -72,14 +72,19 @@
                     (note (pitch :b))
                     (note (pitch :a))
                     (note (pitch :g))))))))))
-  (testing "an unclosed voice group"
-    (testing "implicitly closes at the end of a set-variable"
-      (let [{:keys [voice-instruments]} (score (set-variable :foo (voices (voice 1 (note (pitch :a))))))]
-        (is (nil? voice-instruments))))
-    (testing "implicitly closes at the end of a sequence"
-      (let [{:keys [voice-instruments]} (score [(voices (voice 1 (note (pitch :a))))])]
-        (is (nil? voice-instruments))))
-    (testing "does not implicitly close alone"
-      (let [{:keys [voice-instruments]} (score (voices (voice 1 (note (pitch :a)))))]
-        (is (some? voice-instruments))))))
+  (testing "a voice group"
+    (testing "can be repeated manually, closed"
+      (let [vs (voices (voice 1 (note (pitch :a))))
+            s (score (part "piano" [vs (end-voices) vs]))]
+        (is (= 2 (count (:events s))))))
+    (testing "can be repeated manually, unclosed"
+      (let [vs (voices (voice 1 (note (pitch :a))))
+            s (score (part "piano" [vs vs]))]
+        (is (= 2 (count (:events s))))))
+    (testing "can be repeated, closed"
+      (let [s (score (part "piano" (times 2 [(voices (voice 1 (note (pitch :a)))) (end-voices)])))]
+        (is (= 2 (count (:events s))))))
+    (testing "can be repeated, unclosed"
+      (let [s (score (part "piano" (times 2 (voices (voice 1 (note (pitch :a)))))))]
+        (is (= 2 (count (:events s))))))))
 

--- a/server/test/alda/lisp/voices_test.clj
+++ b/server/test/alda/lisp/voices_test.clj
@@ -86,5 +86,15 @@
         (is (= 2 (count (:events s))))))
     (testing "can be repeated, unclosed"
       (let [s (score (part "piano" (times 2 (voices (voice 1 (note (pitch :a)))))))]
-        (is (= 2 (count (:events s))))))))
+        (is (= 2 (count (:events s))))))
+    (testing "left unclosed, leaves instrument state intact"
+      (let [s (score (part "piano" (times 2 (voices (voice 1 (note (pitch :a)))))))]
+        (is (not (empty? (:voice-instruments s))))
+        ))
+    (testing "closed, wipes instrument state"
+      (let [s (score (part "piano" (voices (voice 1 (note (pitch :a))) (end-voices))))]
+        (is (empty? (:voice-instruments s)))))
+    (testing "on part transition, wipes instrument state"
+      (let [s (score (part "piano" (voices (voice 1 (note (pitch :a))) (part "guitar" (note (pitch :a))))))]
+        (is (empty? (:voice-instruments s)))))))
 

--- a/server/test/alda/parser/event_sequences_test.clj
+++ b/server/test/alda/parser/event_sequences_test.clj
@@ -20,4 +20,17 @@
               (alda.lisp/note (alda.lisp/pitch :d))
               [(alda.lisp/note (alda.lisp/pitch :e))
                (alda.lisp/note (alda.lisp/pitch :f))]
-              (alda.lisp/note (alda.lisp/pitch :g))])))))
+              (alda.lisp/note (alda.lisp/pitch :g))]))))
+  (testing "voices within event sequences parse successfully"
+    (is (= (parse-to-lisp-with-context :music-data "[V1: e b d V2: a c f]")
+           '([(alda.lisp/voices 
+               (alda.lisp/voice 
+                1
+                (alda.lisp/note (alda.lisp/pitch :e))
+                (alda.lisp/note (alda.lisp/pitch :b))
+                (alda.lisp/note (alda.lisp/pitch :d)))
+               (alda.lisp/voice 
+                2
+                (alda.lisp/note (alda.lisp/pitch :a))
+                (alda.lisp/note (alda.lisp/pitch :c))
+                (alda.lisp/note (alda.lisp/pitch :f))))])))))


### PR DESCRIPTION
I don't have much Alda knowledge, so I've probably missed some use cases. However, this at least tackles the specific problem cases in issue [255](https://github.com/alda-lang/alda/issues/255). It makes two changes that are kind of related, but wouldn't strictly have to be part of the same PR if one of them doesn't check out.

1. Use lookahead to allow an unclosed voice group to parse as part of an event sequence. This addresses the parse error caused by `piano: [V1: c d e V2: e f g]*2`.

2. Unconditionally close any `:event-sequence` (including variable defs) with an `:end-voice-group`. This allows `foo = V1: c d e V2: e f g` to be multiplied by `foo*2`. From a design standpoint, though, I'm not sure if you want this behavior so broadly. The comments on the issue implied that maybe you do, but please correct me!

> The issue here seems to be that voice groups do not implicitly end at the end of a variable definition, which can cause unexpected behavior.

Right now the `:end-voice-group` is unconditional, even if, for instance, the sequence already ends with `:end-voice-group` or doesn't end with `:voice-group` at all! I wanted to get the change out there for discussion before optimizing.

I wrote some tests to cover my limited knowledge. Let me know what you think!