### PR TITLE
Add support for dynamic markings 

### DIFF
--- a/client/model/attributes.go
+++ b/client/model/attributes.go
@@ -334,6 +334,35 @@ func (tvs TrackVolumeSet) updatePart(part *Part, globalUpdate bool) {
 	part.TrackVolume = tvs.TrackVolume
 }
 
+var DynamicVolumes map[string]float64
+
+func init() {
+	DynamicVolumes = map[string]float64{
+		"pppp": 0.05,
+		"ppp":  0.10,
+		"pp":   0.20,
+		"p":    0.30,
+		"mp":   0.40,
+		"mf":   0.50,
+		"f":    0.60,
+		"ff":   0.70,
+		"fff":  0.80,
+		"ffff": 0.90,
+	}
+}
+
+type DynamicMarking struct {
+	Marking string
+}
+
+func (dm DynamicMarking) JSON() *json.Container {
+	return json.Object("attribute", "dynamic-marking", "value", dm.Marking)
+}
+
+func (dm DynamicMarking) updatePart(part *Part, globalUpdate bool) {
+	part.Volume = DynamicVolumes[dm.Marking]
+}
+
 // PanningSet sets the panning of all active parts.
 type PanningSet struct {
 	Panning float64

--- a/client/model/attributes.go
+++ b/client/model/attributes.go
@@ -337,17 +337,27 @@ func (tvs TrackVolumeSet) updatePart(part *Part, globalUpdate bool) {
 var DynamicVolumes map[string]float64
 
 func init() {
+	// Dynamic volumes in Alda follow a uniform distribution from 0 to 1
+	// This follows the standard set by MIDI and existing software programs
+	// Alda supports the full range of MusicXML dynamics from pppppp to ffffff
+	// Volumes are mapped to MIDI velocity [0, 127] by multiplying by 127
+	// The default Alda volume is mf
+	// MIDI velocities are commented
 	DynamicVolumes = map[string]float64{
-		"pppp": 0.05,
-		"ppp":  0.10,
-		"pp":   0.20,
-		"p":    0.30,
-		"mp":   0.40,
-		"mf":   0.50,
-		"f":    0.60,
-		"ff":   0.70,
-		"fff":  0.80,
-		"ffff": 0.90,
+		"pppppp": 0.00787, // 1
+		"ppppp":  0.08419, // 11
+		"pppp":   0.16051, // 20
+		"ppp":    0.23683, // 30
+		"pp":     0.31314, // 40
+		"p":      0.38946, // 49
+		"mp":     0.46578, // 59
+		"mf":     0.54210, // 69
+		"f":      0.61841, // 79
+		"ff":     0.69473, // 88
+		"fff":    0.77105, // 98
+		"ffff":   0.84737, // 108
+		"fffff":  0.92368, // 117
+		"ffffff": 1.00000, // 127
 	}
 }
 

--- a/client/model/attributes_test.go
+++ b/client/model/attributes_test.go
@@ -331,7 +331,7 @@ func TestAttributes(t *testing.T) {
 				PartDeclaration{Names: []string{"piano"}},
 			},
 			expectations: []scoreUpdateExpectation{
-				expectPartVolume("piano", 1.0),
+				expectPartVolume("piano", DynamicVolumes["mf"]),
 			},
 		},
 		scoreUpdateTestCase{
@@ -364,7 +364,7 @@ func TestAttributes(t *testing.T) {
 				AttributeUpdate{PartUpdate: DynamicMarking{Marking: "ppp"}},
 			},
 			expectations: []scoreUpdateExpectation{
-				expectPartVolume("piano", 0.23683),
+				expectPartVolume("piano", DynamicVolumes["ppp"]),
 			},
 		},
 		scoreUpdateTestCase{

--- a/client/model/attributes_test.go
+++ b/client/model/attributes_test.go
@@ -358,6 +358,16 @@ func TestAttributes(t *testing.T) {
 			},
 		},
 		scoreUpdateTestCase{
+			label: "set volume using dynamic marking",
+			updates: []ScoreUpdate{
+				PartDeclaration{Names: []string{"piano"}},
+				AttributeUpdate{PartUpdate: DynamicMarking{Marking: "ppp"}},
+			},
+			expectations: []scoreUpdateExpectation{
+				expectPartVolume("piano", 0.23683),
+			},
+		},
+		scoreUpdateTestCase{
 			label: "initial track volume",
 			updates: []ScoreUpdate{
 				PartDeclaration{Names: []string{"piano"}},

--- a/client/model/lisp.go
+++ b/client/model/lisp.go
@@ -229,6 +229,10 @@ func argumentsMatchSignature(
 
 	totalArgs := len(signature.ArgumentTypes)
 
+	if totalArgs == 0 && len(signature.ArgumentTypes) == 0 {
+		return true
+	}
+
 	variadic := false
 	switch signature.ArgumentTypes[totalArgs-1].(type) {
 	case LispVariadic:
@@ -990,6 +994,22 @@ func init() {
 			},
 		},
 	)
+
+	// Dynamic markings corresponding to a volume set
+	var dynamicImplementation = func(marking string) func(args ...LispForm) (PartUpdate, error) {
+		return func(args ...LispForm) (PartUpdate, error) {
+			return DynamicMarking{Marking: marking}, nil
+		}
+	}
+
+	for marking := range DynamicVolumes {
+		defattribute([]string{marking},
+			attributeFunctionSignature{
+				argumentTypes: []LispForm{},
+				implementation: dynamicImplementation(marking),
+			},
+		)
+	}
 
 	// Current panning. 0 = hard left, 100 = hard right.
 	defattribute([]string{"panning", "pan"},

--- a/client/model/lisp.go
+++ b/client/model/lisp.go
@@ -229,7 +229,7 @@ func argumentsMatchSignature(
 
 	totalArgs := len(signature.ArgumentTypes)
 
-	if totalArgs == 0 && len(signature.ArgumentTypes) == 0 {
+	if totalArgs == 0 && len(arguments) == 0 {
 		return true
 	}
 

--- a/client/model/part.go
+++ b/client/model/part.go
@@ -152,7 +152,7 @@ func (score *Score) NewPart(name string) (*Part, error) {
 		Octave:          4,
 		Tempo:           120,
 		TempoValues:     map[float64]float64{},
-		Volume:          1.0,
+		Volume:          DynamicVolumes["mf"],
 		TrackVolume:     100.0 / 127,
 		Panning:         0.5,
 		Quantization:    0.9,

--- a/client/parser/lisp_test.go
+++ b/client/parser/lisp_test.go
@@ -35,6 +35,13 @@ func TestLisp(t *testing.T) {
 	executeParseTestCases(
 		t,
 		parseTestCase{
+			label: "attribute change with no value",
+			given: "(fff)",
+			expect: []model.ScoreUpdate{
+				lispList(lispSymbol("fff")),
+			},
+		},
+		parseTestCase{
 			label: "attribute change with number value",
 			given: "(volume 50)",
 			expect: []model.ScoreUpdate{

--- a/doc/alda-2-migration-guide.md
+++ b/doc/alda-2-migration-guide.md
@@ -10,7 +10,7 @@ is a from-scratch rewrite in Go and Kotlin.
 Alda 2 is mostly backwards compatible with Alda 1, to the extent that most of
 the scores that you may have written with Alda 1 should work with Alda 2 and
 sound exactly the same. The implementation of Alda has been rewritten from the
-ground up, but Alda the language remains almost exactly the same.
+ground up, but Alda the language remains almost identical.
 
 There is one important change to the language in Alda 2: **inline Clojure code
 is no longer supported**. This is for obvious reasons: The Alda client is now
@@ -189,6 +189,17 @@ The following attributes are affected by syntax changes in Alda 2:
 All other attributes should work just fine, but please [let us
 know][open-an-issue] if you run into any other backwards compatibility issues
 with your existing Alda 1 scores!
+
+## Score starting volumes 
+
+Alda 1 started all scores at an Alda volume of 100 corresponding to a MIDI 
+velocity of 127. This is the maximum value. With Alda 2, you can now specify 
+volumes with dynamic markings such as `(mp)` or `(ff)`. 
+
+With this addition, all scores now default to a dynamic volume of `(mf)` 
+equivalent to `(vol 54)`. This means that if you previously relied on scores 
+starting from a volume of 100 in Alda 1, you now have to specify this attribute 
+at the beginning of your Alda 2 score. 
 
 ## Programmatic composition
 

--- a/doc/attributes.md
+++ b/doc/attributes.md
@@ -277,4 +277,24 @@ cello:
 
 * **Value:** a number between 0 and 100
 
-* **Initial Value:** 100
+* **Initial Value:** 54 (corresponding to a `(mf)` marking)
+
+### Dynamic Markings 
+
+* **Description:** Aside from setting the volume of a note directly, you can 
+  also specify dynamic markings which correspond to fixed volumes following MIDI
+  standards. 
+  
+* **Available Dynamics:** 
+
+  | Dynamic Marking | Matching Volume   | Dynamic Marking | Matching Volume   |
+  |-----------------|-------------------|-----------------|-------------------|
+  | `(pppppp)`      | `(vol 1)`         | `(mf)`          | `(vol 54)`        |
+  | `(ppppp)`       | `(vol 8)`         | `(f)`           | `(vol 62)`        |
+  | `(pppp)`        | `(vol 16)`        | `(ff)`          | `(vol 69)`        |
+  | `(ppp)`         | `(vol 24)`        | `(fff)`         | `(vol 77)`        |
+  | `(pp)`          | `(vol 31)`        | `(ffff)`        | `(vol 85)`        |
+  | `(p)`           | `(vol 39)`        | `(fffff)`       | `(vol 92)`        |
+  | `(mp)`          | `(vol 46)`        | `(ffffff)`      | `(vol 100)`       |
+
+* **Initial Value:** `(mf)` (corresponding to a volume of 54) 

--- a/examples/bach_cello_suite_no_1.alda
+++ b/examples/bach_cello_suite_no_1.alda
@@ -44,7 +44,7 @@ cello "main":
   # Simulating notes weaving around the open A string by using a second cello
   # for the A string.
   %weaving
-  (quant 65) (volume 100)
+  (quant 65)
   o3 g8 a b d a b > c < d b > c d < b > | c < b > c < a b a b g |
   o3 a g a f+
 
@@ -64,5 +64,5 @@ cello "main":
 # Just the open A string of the %weaving part above.
 cello "aux":
   @weaving
-  (quant 65) (volume 70)
+  (quant 65) (p)
   o3 r16 a8 a a a | a a a a a a a a | a a a a a a a a | a a a a

--- a/examples/debussy_quartet.alda
+++ b/examples/debussy_quartet.alda
@@ -6,48 +6,48 @@
 
 violin "violin-1":
   o4
-  (quant 40) g4 (quant 90) f4~8 d8 f {a-~ b~ a-~} | g8 f4 g8 d4 d
+  (ff) (quant 40) g4 (quant 90) f4~8 d8 f {a-~ b~ a-~} | g8 f4 g8 d4 d
   b8 r g4~8 b8 {g b > d <}4 | b8 r g4~8 b8 {g b > d <}4 |
 
   (quant 40) > g4 (quant 90) f4~8 d8 f {a-~ b~ a-~} |
   g8 f4~ g8 d4~8~ {e~ f~ e~}8 |
 
-  d8 < (vol 85) b_4~ > c8 (vol 75) < a-4~8 {a-~ b~ a-~}8 |
+  d8 < (ff) b_4~ > c8 (f) < a-4~8 {a-~ b~ a-~}8 |
   g8 f4~ g8 d4~8~ {a-~ b~ a-~}8 | g8 f4~ g8 d8 f4~ {a-~ b~ a-}8
 
-  g8 f4~ g8 (vol 65) d8 f4~ g8 | d2 r8 f4~ g8 | d2 r2 | r4 > d2 d4~ |
+  g8 f4~ g8 (mf) d8 f4~ g8 | d2 r8 f4~ g8 | d2 r2 | r4 > d2 d4~ |
 
 violin "violin-2":
   o3
-  (quant 40) b4 (quant 90) > c4~8 < b8 > c c < | b > c4 < b8 b4 > c~ < |
+  (ff) (quant 40) b4 (quant 90) > c4~8 < b8 > c c < | b > c4 < b8 b4 > c~ < |
   b8 r b2~12 > d12 g | d8 r < b4~8~ > d8 < {b > d g}4 |
 
-  (quant 40) b4 (quant 90) a4~8 a-8 g a-8~|2. a-4~|2. (vol 75) e4 |
+  (quant 40) b4 (quant 90) a4~8 a-8 g a-8~|2. a-4~|2. (f) e4 |
   d4.~ c8 < b4~ a- | > e2~ < a-
 
-  > e2 (vol 65) < a-8 > e4~ < b8 | > c2 r8 e4~ < b8 | > c2 r2 |
-  (vol 40) d16~ e_~ d~ e_~ (vol 50) f+~ g~ f+~ g~
-  (vol 60) a~ b~ a~ b~ (vol 70) > c~ d~ c~ d~
+  > e2 (mf) < a-8 > e4~ < b8 | > c2 r8 e4~ < b8 | > c2 r2 |
+  (pp) d16~ e_~ d~ e_~ (p) f+~ g~ f+~ g~
+  (mp) a~ b~ a~ b~ (mf) > c~ d~ c~ d~
 
 viola:
   o3
-  (quant 40) d4 (quant 90) d4~8 f8 d d | d d4 g8 f4 f+~ |
+  (ff) (quant 40) d4 (quant 90) d4~8 f8 d d | d d4 g8 f4 f+~ |
   g8 r f+4 f {e_ g b}4 | g8 r f+4 f {e_ g b}4 |
 
   (quant 40) > d4 (quant 90) e-4~8 e8 d- c | < b_ > d4~ f8 < b_4 > c |
-  < b_8 > (vol 85) d4~ e8 (vol 75) c2 | < a-2. > c4 < a2~ f
+  < b_8 > (ff) d4~ e8 (f) c2 | < a-2. > c4 < a2~ f
 
-  b_2 > (vol 65) c8 c4~ d8 | < a-2 r8 > c4~ d8 | < a-2 r8 f4~ (vol 50) g8 |
-  (vol 40) a_16~ b~ a_~ b_ (vol 50) > c~ d~ c~ d~
-  (vol 60) e~ f~ e~ f~ (vol 70) g~ a~ g~ a~
+  b_2 > (mf) c8 c4~ d8 | < a-2 r8 > c4~ d8 | < a-2 r8 f4~ (p) g8 |
+  (pp) a_16~ b~ a_~ b_ (p) > c~ d~ c~ d~
+  (mp) e~ f~ e~ f~ (mf) g~ a~ g~ a~
 
 cello:
   o2
-  (quant 50) g4 (quant 90) a-4~8 b8 a- f | g a-4 g8 b4 a- | g1 | g |
+  (ff) (quant 50) g4 (quant 90) a-4~8 b8 a- f | g a-4 g8 b4 a- | g1 | g |
 
-  (quant 50) > c4 (quant 90) f4~8 < b8 > e < a-8~2./>e < a-4~2./>e (vol 75) < a-4 |
+  (quant 50) > c4 (quant 90) f4~8 < b8 > e < a-8~2./>e < a-4~2./>e (f) < a-4 |
   b_8 > d4~ e8 e_4~ f b_2~ > c
 
   < a-2 f8 a-4~ g8 | f f4~ g8 d a-4~ g8 | f f4~ g8 d r r4 |
-  (vol 40) f+16~ g~ f+~ g~ (vol 50) a~ b~ a~ b~
-  (vol 60) > c~ d~ c~ d~ (vol 70) e~ f~ e~ f~
+  (pp) f+16~ g~ f+~ g~ (p) a~ b~ a~ b~
+  (mp) > c~ d~ c~ d~ (mf) e~ f~ e~ f~

--- a/examples/dynamics.alda
+++ b/examples/dynamics.alda
@@ -1,0 +1,32 @@
+piano:
+     c8
+     (pppppp)
+     d
+     (ppppp)
+     e
+     (pppp)
+     f
+     (ppp)
+     g
+     (pp)
+     a
+     (p)
+     b
+     (mp)
+     > c
+     (mf)
+     < b
+     (f)
+     a
+     (ff)
+     g
+     (fff)
+     f
+     (ffff)
+     e
+     (fffff)
+     d
+     (ffffff)
+     c4
+     (pppppp)
+     c4 e4 g4

--- a/examples/dynamics.alda
+++ b/examples/dynamics.alda
@@ -28,5 +28,3 @@ piano:
      d
      (ffffff)
      c4
-     (pppppp)
-     c4 e4 g4

--- a/examples/rachmaninoff_piano_concerto_2_mvmt_2.alda
+++ b/examples/rachmaninoff_piano_concerto_2_mvmt_2.alda
@@ -132,7 +132,7 @@ clarinet:
     V1: b1 | r4 g4~8 g8 f_ g g a- f_ e | g2~8 f+8 g f+ | g2~4 r4
     V2: r2 <d2 | c2 r1 | r1 | r2 e4 e_
 
-    V1: r4 b4~8 b8 a b b >c <a g | b2~8 b8 a b b >c <b g+ | a2~8 b8 g_ f
+    V1: r4 b4~8 b8 a b b >c <a g | b2~8 b8 a b b >c <a g+ | a2~8 b8 g_ f
     V2: d2
 
 flute:


### PR DESCRIPTION
Alda supports volume setting via `(vol __)` and `(vol! __)` attribute updates. Many scores do not necessarily have numeric volumes, but instead have dynamic markings. This PR introduces basic dynamic markings into Alda via Lisp attribute updates. 

## Dynamic Markings
This PR will introduce the `(mf)` and `(mp)` dynamic markings, as well as the `(pppppp)`, ..., `(p)` and `(ffffff)`, ..., `(f)` markings. We choose to support up to 6 pianos or fortes following the MusicXML standard [here](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/dynamics/). 

This PR does not add support for more complex dynamics such as fortepiano or sforzando. We believe this would add unnecessary complication into the Alda language. 

## Dynamic Volumes
A MIDI note's volume is represented by velocity which is an integer in the range `[0, 127]`. The majority of existing software maps dynamics to velocities following a linear scale. See the Wiki page [here](https://en.wikipedia.org/wiki/Dynamics_(music)#Interpretation_by_notation_programs). Alda will follow a similar uniform distribution, but supporting up to 6 pianos and fortes instead of the usual 3. 

Alda internal representation uses a float in the range `[0, 1]` instead of velocity. I have added a mapping with velocities commented. 

## Default Dynamic
With the introduction of dynamics, we will also change every Alda score to start with a default dynamic. We select `mf` as the default dynamic following MuseScore as explained [here](https://musescore.org/en/handbook/3/dynamics#:~:text=The%20default%20dynamic%20of%20the,than%20or%20greater%20than%20this.). 