### PR TITLE
Decompiler - Code Generator

### DIFF
--- a/client/code_generator/generator.go
+++ b/client/code_generator/generator.go
@@ -1,10 +1,289 @@
 package code_generator
 
 import (
+	"alda.io/client/color"
+	log "alda.io/client/logging"
 	"alda.io/client/model"
 	"alda.io/client/parser"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
 )
 
+type generator struct {
+	tokens []parser.Token
+}
+
+func (g *generator) addToken(tokenType parser.TokenType, text string) {
+	g.tokens = append(g.tokens, parser.Token{TokenType: tokenType, Text: text})
+}
+
+func (g *generator) generateAttributeUpdate(au model.AttributeUpdate) {
+	switch partUpdate := au.PartUpdate.(type) {
+	case model.OctaveSet:
+		g.addToken(
+			parser.OctaveSet, fmt.Sprintf("o%d", partUpdate.OctaveNumber),
+		)
+	case model.OctaveUp:
+		g.addToken(parser.OctaveUp, ">")
+	case model.OctaveDown:
+		g.addToken(parser.OctaveDown, "<")
+	default:
+		// No other AttributeUpdates can be introduced directly into Alda
+		g.logError(partUpdate)
+	}
+}
+
+func (g *generator) logError(structure interface{}) {
+	log.Error().Msg(fmt.Sprintf(
+		`Alda code generator cannot process struct with type %s`,
+		color.Aurora.BrightYellow(reflect.TypeOf(structure).Name()),
+	))
+}
+
+func (g *generator) generateGlobalAttributeUpdate(
+	ga model.GlobalAttributeUpdate,
+) {
+	// GlobalAttributeUpdates can only be introduced using Lisp
+	g.logError(ga)
+}
+
+func (g *generator) generateBarline(_ model.Barline) {
+	g.addToken(parser.Barline, "|")
+}
+
+func (g *generator) generateChord(chord model.Chord) {
+	for index, update := range chord.Events {
+		g.generateTokens([]model.ScoreUpdate{update})
+
+		if index < len(chord.Events) - 1 {
+			g.addToken(parser.Separator, "/")
+		}
+	}
+}
+
+func (g *generator) generateCram(cram model.Cram) {
+	g.addToken(parser.CramOpen, "{")
+	g.generateTokens(cram.Events)
+	g.addToken(parser.CramClose, "}")
+}
+
+func (g *generator) generateEventSequence(es model.EventSequence) {
+	g.addToken(parser.EventSeqOpen, "[")
+	g.generateTokens(es.Events)
+	g.addToken(parser.EventSeqClose, "]")
+}
+
+func (g *generator) generateLispNil(n model.LispNil) {
+	g.logError(n)
+}
+
+func (g *generator) generateLispList(l model.LispList) {
+	for _, element := range l.Elements {
+		switch lispForm := element.(type) {
+		case model.LispNumber:
+			g.addToken(parser.Number, fmt.Sprintf("%f", lispForm.Value))
+		case model.LispString:
+			g.addToken(parser.String, lispForm.Value)
+		case model.LispSymbol:
+			g.addToken(parser.Symbol, lispForm.Name)
+		case model.LispSpecialFormQuote:
+		case model.LispAny:
+		case model.LispVariadic:
+		case model.LispFunction:
+		case model.LispNil:
+		case model.LispQuotedForm:
+		case model.LispScoreUpdate:
+		case model.LispPitch:
+		case model.LispDuration:
+		case model.LispList:
+		default:
+			g.logError(element)
+		}
+	}
+}
+
+func (g *generator) generateMarker(marker model.Marker) {
+	g.addToken(parser.Marker, "%" + marker.Name)
+}
+
+func (g *generator) generateAtMarker(atMarker model.AtMarker) {
+	g.addToken(parser.AtMarker, "@" + atMarker.Name)
+}
+
+func (g *generator) generatePitch(pitch model.PitchIdentifier) {
+	// PitchIdentifier can be a LetterAndAccidentals or a MidiNoteNumber
+	// However, note's are never generated directly with a MidiNoteNumber pitch
+	// When parsing Alda itself, MidiNoteNumber is only used with Lisp
+	// When building Alda from the MusicXML importer, MidiNoteNumbers are
+	// transformed to LetterAndAccidentals during optimization
+	if reflect.TypeOf(pitch) == reflect.TypeOf(model.MidiNoteNumber{}) {
+		g.logError(pitch)
+	}
+
+	laa := pitch.(model.LetterAndAccidentals)
+	g.addToken(parser.NoteLetter, strings.ToLower(laa.NoteLetter.String()))
+
+	for _, accidental := range laa.Accidentals {
+		switch accidental {
+		case model.Flat:
+			g.addToken(parser.Flat, "-")
+		case model.Natural:
+			g.addToken(parser.Natural, "_")
+		case model.Sharp:
+			g.addToken(parser.Sharp, "+")
+		}
+	}
+}
+
+func (g *generator) generateDuration(duration model.Duration) {
+	for _, component := range duration.Components {
+		switch value := component.(type) {
+		case model.Barline:
+			g.generateBarline(value)
+		case model.NoteLength:
+			noteLength := fmt.Sprintf("%f", value.Denominator) +
+				strings.Repeat(".", int(value.Dots))
+			g.addToken(parser.NoteLength, noteLength)
+		case model.NoteLengthMs:
+			noteLengthMs := fmt.Sprintf("%f", value.Quantity) + "ms"
+			g.addToken(parser.NoteLengthMs, noteLengthMs)
+		case model.NoteLengthBeats:
+			// NoteLengthBeats is only generated from Lisp
+			g.logError(component)
+		}
+	}
+}
+
+func (g *generator) generateNote(note model.Note) {
+	g.generatePitch(note.Pitch)
+	g.generateDuration(note.Duration)
+	if note.Slurred {
+		g.addToken(parser.Tie, "~")
+	}
+}
+
+func (g *generator) generateRest(rest model.Rest) {
+	g.addToken(parser.RestLetter, "r")
+	g.generateDuration(rest.Duration)
+}
+
+func (g *generator) generatePartDeclaration(decl model.PartDeclaration) {
+	for i, name := range decl.Names {
+		if i > 0 {
+			g.addToken(parser.Separator, "/")
+		}
+		g.addToken(parser.Name, name)
+	}
+
+	if decl.Alias != "" {
+		g.addToken(parser.Alias, "\"" + decl.Alias + "\"")
+	}
+
+	g.addToken(parser.Colon, ":")
+}
+
+func (g *generator) generateRepeat(repeat model.Repeat) {
+	g.generateTokens([]model.ScoreUpdate{repeat.Event})
+	g.addToken(parser.Repeat, "*" + strconv.Itoa(int(repeat.Times)))
+}
+
+func (g *generator) generateOnRepetitions(or model.OnRepetitions) {
+	g.generateTokens([]model.ScoreUpdate{or.Event})
+
+	repetitionsText := "'"
+	for i, repetition := range or.Repetitions {
+		if i > 0 {
+			repetitionsText += ","
+		}
+		if repetition.First == repetition.Last {
+			repetitionsText += strconv.Itoa(int(repetition.First))
+		} else {
+			repetitionsText += strconv.Itoa(int(repetition.First))
+			repetitionsText += "-"
+			repetitionsText += strconv.Itoa(int(repetition.Last))
+		}
+	}
+
+	g.addToken(parser.Repetitions, repetitionsText)
+}
+
+func (g *generator) generateVariableDeclaration(vd model.VariableDefinition) {
+	g.addToken(parser.Name, vd.VariableName)
+	g.addToken(parser.Equals, "=")
+	g.generateTokens(vd.Events)
+}
+
+func (g *generator) generateVariableReference(vr model.VariableReference) {
+	g.addToken(parser.Name, vr.VariableName)
+}
+
+func (g *generator) generateVoiceMarker(vm model.VoiceMarker) {
+	g.addToken(
+		parser.VoiceMarker,
+		"V" + strconv.Itoa(int(vm.VoiceNumber)) + ":",
+	)
+}
+
+func (g *generator) generateVoiceGroupEndMarker(_ model.VoiceGroupEndMarker) {
+	g.addToken(parser.VoiceMarker, "V0:")
+}
+
+func (g *generator) generateTokens(scoreUpdates []model.ScoreUpdate) {
+	for _, update := range scoreUpdates {
+		switch value := update.(type) {
+		case model.AttributeUpdate:
+			g.generateAttributeUpdate(value)
+		case model.GlobalAttributeUpdate:
+			g.generateGlobalAttributeUpdate(value)
+		case model.Barline:
+			g.generateBarline(value)
+		case model.Chord:
+			g.generateChord(value)
+		case model.Cram:
+			g.generateCram(value)
+		case model.EventSequence:
+			g.generateEventSequence(value)
+		case model.LispNil:
+			g.generateLispNil(value)
+		case model.LispList:
+			g.generateLispList(value)
+		case model.Marker:
+			g.generateMarker(value)
+		case model.AtMarker:
+			g.generateAtMarker(value)
+		case model.Note:
+			g.generateNote(value)
+		case model.Rest:
+			g.generateRest(value)
+		case model.PartDeclaration:
+			g.generatePartDeclaration(value)
+		case model.Repeat:
+			g.generateRepeat(value)
+		case model.OnRepetitions:
+			g.generateOnRepetitions(value)
+		case model.VariableDefinition:
+			g.generateVariableDeclaration(value)
+		case model.VariableReference:
+			g.generateVariableReference(value)
+		case model.VoiceMarker:
+			g.generateVoiceMarker(value)
+		case model.VoiceGroupEndMarker:
+			g.generateVoiceGroupEndMarker(value)
+		}
+	}
+}
+
+// Generate transforms Alda score updates into tokens for the purpose of
+// generating idiomatic Alda as the first step of the Alda decompiler
+// Generate does not generate tokens equivalent to parsed tokens, and instead
+// drops token literals as they are unnecessary for formatting token text
+// Generate operates on a subset of valid Alda, and is meant to be run against
+// score updates as imported from external sources such as MusicXML
 func Generate(scoreUpdates []model.ScoreUpdate) []parser.Token {
-	return nil
+	var g generator
+	g.generateTokens(scoreUpdates)
+	g.addToken(parser.EOF, "")
+	return g.tokens
 }

--- a/client/code_generator/generator.go
+++ b/client/code_generator/generator.go
@@ -19,6 +19,13 @@ func (g *generator) addToken(tokenType parser.TokenType, text string) {
 	g.tokens = append(g.tokens, parser.Token{TokenType: tokenType, Text: text})
 }
 
+func (g *generator) logError(structure interface{}) {
+	log.Error().Msg(fmt.Sprintf(
+		`Alda code generator cannot process struct with type %s`,
+		color.Aurora.BrightYellow(reflect.TypeOf(structure).Name()),
+	))
+}
+
 func (g *generator) generateAttributeUpdate(au model.AttributeUpdate) {
 	switch partUpdate := au.PartUpdate.(type) {
 	case model.OctaveSet:
@@ -33,13 +40,6 @@ func (g *generator) generateAttributeUpdate(au model.AttributeUpdate) {
 		// No other AttributeUpdates can be introduced directly into Alda
 		g.logError(partUpdate)
 	}
-}
-
-func (g *generator) logError(structure interface{}) {
-	log.Error().Msg(fmt.Sprintf(
-		`Alda code generator cannot process struct with type %s`,
-		color.Aurora.BrightYellow(reflect.TypeOf(structure).Name()),
-	))
 }
 
 func (g *generator) generateGlobalAttributeUpdate(
@@ -80,28 +80,7 @@ func (g *generator) generateLispNil(n model.LispNil) {
 }
 
 func (g *generator) generateLispList(l model.LispList) {
-	for _, element := range l.Elements {
-		switch lispForm := element.(type) {
-		case model.LispNumber:
-			g.addToken(parser.Number, fmt.Sprintf("%f", lispForm.Value))
-		case model.LispString:
-			g.addToken(parser.String, lispForm.Value)
-		case model.LispSymbol:
-			g.addToken(parser.Symbol, lispForm.Name)
-		case model.LispSpecialFormQuote:
-		case model.LispAny:
-		case model.LispVariadic:
-		case model.LispFunction:
-		case model.LispNil:
-		case model.LispQuotedForm:
-		case model.LispScoreUpdate:
-		case model.LispPitch:
-		case model.LispDuration:
-		case model.LispList:
-		default:
-			g.logError(element)
-		}
-	}
+	g.logError(l)
 }
 
 func (g *generator) generateMarker(marker model.Marker) {

--- a/client/code_generator/generator_test.go
+++ b/client/code_generator/generator_test.go
@@ -1,1 +1,41 @@
 package code_generator
+
+import (
+	"alda.io/client/model"
+	"alda.io/client/parser"
+	"testing"
+)
+
+func eof() parser.Token {
+	return parser.Token{TokenType: parser.EOF, Text: ""}
+}
+
+func TestGenerator(t *testing.T) {
+	executeGeneratorTestCases(t, generatorTestCase{
+		label: "attribute updates",
+		updates: []model.ScoreUpdate{
+			model.AttributeUpdate{PartUpdate: model.OctaveUp{}},
+			model.AttributeUpdate{PartUpdate: model.OctaveDown{}},
+			model.AttributeUpdate{PartUpdate: model.OctaveSet{OctaveNumber: 1}},
+			model.AttributeUpdate{PartUpdate: model.OctaveSet{OctaveNumber: 3}},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.OctaveUp, Text: ">"},
+			{TokenType: parser.OctaveDown, Text: "<"},
+			{TokenType: parser.OctaveSet, Text: "o1"},
+			{TokenType: parser.OctaveSet, Text: "o3"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "barlines",
+		updates: []model.ScoreUpdate{
+			model.Barline{},
+			model.Barline{},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.Barline, Text: "|"},
+			eof(),
+		},
+	})
+}

--- a/client/code_generator/generator_test.go
+++ b/client/code_generator/generator_test.go
@@ -1,0 +1,1 @@
+package code_generator

--- a/client/code_generator/generator_test.go
+++ b/client/code_generator/generator_test.go
@@ -30,10 +30,263 @@ func TestGenerator(t *testing.T) {
 		label: "barlines",
 		updates: []model.ScoreUpdate{
 			model.Barline{},
-			model.Barline{},
 		},
 		expected: []parser.Token{
 			{TokenType: parser.Barline, Text: "|"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "chords",
+		updates: []model.ScoreUpdate{
+			model.Chord{Events: []model.ScoreUpdate{
+				model.AttributeUpdate{PartUpdate: model.OctaveDown{}},
+				model.Barline{},
+				model.Rest{},
+				model.Barline{},
+				model.AttributeUpdate{PartUpdate: model.OctaveDown{}},
+				model.Rest{},
+				model.Rest{},
+				model.AttributeUpdate{PartUpdate: model.OctaveUp{}},
+			}},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.OctaveDown, Text: "<"},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.RestLetter, Text: "r"},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.OctaveDown, Text: "<"},
+			{TokenType: parser.Separator, Text: "/"},
+			{TokenType: parser.RestLetter, Text: "r"},
+			{TokenType: parser.Separator, Text: "/"},
+			{TokenType: parser.RestLetter, Text: "r"},
+			{TokenType: parser.OctaveUp, Text: ">"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "cram",
+		updates: []model.ScoreUpdate{
+			model.Cram{Duration: model.Duration{
+				Components: []model.DurationComponent{
+					model.NoteLength{Denominator: 4},
+				},
+			}, Events: []model.ScoreUpdate{
+				model.Barline{},
+			}},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.CramOpen, Text: "{"},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.CramClose, Text: "}"},
+			{TokenType: parser.NoteLength, Text: "4"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "event sequence",
+		updates: []model.ScoreUpdate{
+			model.EventSequence{Events: []model.ScoreUpdate{
+				model.Barline{},
+			}},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.EventSeqOpen, Text: "["},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.EventSeqClose, Text: "]"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "markers",
+		updates: []model.ScoreUpdate{
+			model.Marker{Name: "marker1"},
+			model.Marker{Name: "marker2"},
+			model.AtMarker{Name: "marker2"},
+			model.AtMarker{Name: "marker1"},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.Marker, Text: "%marker1"},
+			{TokenType: parser.Marker, Text: "%marker2"},
+			{TokenType: parser.AtMarker, Text: "@marker2"},
+			{TokenType: parser.AtMarker, Text: "@marker1"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "note pitches",
+		updates: []model.ScoreUpdate{
+			model.Note{Pitch: model.LetterAndAccidentals{
+				NoteLetter: model.C,
+				Accidentals: []model.Accidental{model.Sharp, model.Flat},
+			}},
+			model.Note{Pitch: model.LetterAndAccidentals{
+				NoteLetter: model.G,
+				Accidentals: []model.Accidental{model.Natural},
+			}},
+			model.Note{Pitch: model.LetterAndAccidentals{
+				NoteLetter: model.F,
+			}},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.NoteLetter, Text: "c"},
+			{TokenType: parser.Sharp, Text: "+"},
+			{TokenType: parser.Flat, Text: "-"},
+			{TokenType: parser.NoteLetter, Text: "g"},
+			{TokenType: parser.Natural, Text: "_"},
+			{TokenType: parser.NoteLetter, Text: "f"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "rests and durations",
+		updates: []model.ScoreUpdate{
+			model.Rest{},
+			model.Rest{Duration: model.Duration{
+				Components: []model.DurationComponent{
+					model.NoteLength{Denominator: 4},
+				}},
+			},
+			model.Rest{Duration: model.Duration{
+				Components: []model.DurationComponent{
+					model.NoteLengthMs{Quantity: 200},
+				}},
+			},
+			model.Rest{Duration: model.Duration{
+				Components: []model.DurationComponent{
+					model.NoteLength{Denominator: 2, Dots: 3},
+					model.NoteLengthMs{Quantity: 100.12345},
+					model.Barline{},
+					model.NoteLength{Denominator: 3.123},
+					model.Barline{},
+				}},
+			},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.RestLetter, Text: "r"},
+			{TokenType: parser.RestLetter, Text: "r"},
+			{TokenType: parser.NoteLength, Text: "4"},
+			{TokenType: parser.RestLetter, Text: "r"},
+			{TokenType: parser.NoteLengthMs, Text: "200ms"},
+			{TokenType: parser.RestLetter, Text: "r"},
+			{TokenType: parser.NoteLength, Text: "2..."},
+			{TokenType: parser.Tie, Text: "~"},
+			{TokenType: parser.NoteLengthMs, Text: "100.12345ms"},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.Tie, Text: "~"},
+			{TokenType: parser.NoteLength, Text: "3.123"},
+			{TokenType: parser.Barline, Text: "|"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "part declarations",
+		updates: []model.ScoreUpdate{
+			model.PartDeclaration{
+				Names: []string{"name1"},
+			},
+			model.PartDeclaration{
+				Names: []string{"name2", "name3"},
+				Alias: "part1",
+			},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.Name, Text: "name1"},
+			{TokenType: parser.Colon, Text: ":"},
+			{TokenType: parser.Name, Text: "name2"},
+			{TokenType: parser.Separator, Text: "/"},
+			{TokenType: parser.Name, Text: "name3"},
+			{TokenType: parser.Alias, Text: "\"part1\""},
+			{TokenType: parser.Colon, Text: ":"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "repeats",
+		updates: []model.ScoreUpdate{
+			model.Repeat{
+				Event: model.EventSequence{Events: []model.ScoreUpdate{
+					model.Barline{},
+				}},
+				Times: 2,
+			},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.EventSeqOpen, Text: "["},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.EventSeqClose, Text: "]"},
+			{TokenType: parser.Repeat, Text: "*2"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "on repetitions",
+		updates: []model.ScoreUpdate{
+			model.OnRepetitions{
+				Event: model.EventSequence{Events: []model.ScoreUpdate{
+					model.Barline{},
+				}},
+				Repetitions: []model.RepetitionRange{
+					{First: 1, Last: 1},
+				},
+			},
+			model.OnRepetitions{
+				Event: model.EventSequence{Events: []model.ScoreUpdate{
+					model.Barline{},
+				}},
+				Repetitions: []model.RepetitionRange{
+					{First: 1, Last: 2},
+				},
+			},
+			model.OnRepetitions{
+				Event: model.EventSequence{Events: []model.ScoreUpdate{
+					model.Barline{},
+				}},
+				Repetitions: []model.RepetitionRange{
+					{First: 1, Last: 2},
+					{First: 3, Last: 3},
+					{First: 5, Last: 7},
+				},
+			},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.EventSeqOpen, Text: "["},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.EventSeqClose, Text: "]"},
+			{TokenType: parser.Repetitions, Text: "'1"},
+			{TokenType: parser.EventSeqOpen, Text: "["},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.EventSeqClose, Text: "]"},
+			{TokenType: parser.Repetitions, Text: "'1-2"},
+			{TokenType: parser.EventSeqOpen, Text: "["},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.EventSeqClose, Text: "]"},
+			{TokenType: parser.Repetitions, Text: "'1-2,3,5-7"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "variables",
+		updates: []model.ScoreUpdate{
+			model.VariableDefinition{
+				VariableName: "var1",
+				Events: []model.ScoreUpdate{model.Barline{}},
+			},
+			model.VariableReference{VariableName: "var1"},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.Name, Text: "var1"},
+			{TokenType: parser.Equals, Text: "="},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.Name, Text: "var1"},
+			eof(),
+		},
+	}, generatorTestCase{
+		label: "voices",
+		updates: []model.ScoreUpdate{
+			model.VoiceMarker{VoiceNumber: 1},
+			model.Barline{},
+			model.VoiceMarker{VoiceNumber: 2},
+			model.Barline{},
+			model.VoiceGroupEndMarker{},
+			model.Barline{},
+		},
+		expected: []parser.Token{
+			{TokenType: parser.VoiceMarker, Text: "V1:"},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.VoiceMarker, Text: "V2:"},
+			{TokenType: parser.Barline, Text: "|"},
+			{TokenType: parser.VoiceMarker, Text: "V0:"},
 			{TokenType: parser.Barline, Text: "|"},
 			eof(),
 		},

--- a/client/code_generator/test_helper.go
+++ b/client/code_generator/test_helper.go
@@ -1,0 +1,29 @@
+package code_generator
+
+import (
+	"alda.io/client/model"
+	"alda.io/client/parser"
+	"github.com/go-test/deep"
+	"testing"
+)
+
+type generatorTestCase struct {
+	label    string
+	updates  []model.ScoreUpdate
+	expected []parser.Token
+}
+
+func executeGeneratorTestCases(
+	t *testing.T, testCases ...generatorTestCase,
+) {
+	for _, testCase := range testCases {
+		actual := Generate(testCase.updates)
+
+		if diff := deep.Equal(testCase.expected, actual); diff != nil {
+			t.Error(testCase.label)
+			for _, diffItem := range diff {
+				t.Errorf("%v", diffItem)
+			}
+		}
+	}
+}

--- a/client/code_generator/util.go
+++ b/client/code_generator/util.go
@@ -1,0 +1,16 @@
+package code_generator
+
+import (
+	"fmt"
+	"strings"
+)
+
+func formatFloat(quantity float64) string {
+	return strings.TrimRight(
+		strings.TrimRight(
+			fmt.Sprintf("%f", quantity),
+			"0",
+		),
+		".",
+	)
+}


### PR DESCRIPTION
This PR will introduce the Alda code generator as part of the complete decompiler. 

The code generator exists to process Alda IR that has no corresponding Alda code file. Currently, the only use case for this is the MusicXML importer. 