### PR TITLE
Decompiler - Code Formatter

### DIFF
--- a/client/code_formatter/formatter.go
+++ b/client/code_formatter/formatter.go
@@ -6,6 +6,9 @@ import (
 	"io"
 )
 
+// Format formats Alda token text into readable code
+// Format can be used as the last step in the decompiler process, or by itself
+// as a standalone formatting command 
 func Format(tokens []parser.Token, w io.Writer) {
 	for _, token := range tokens {
 		fmt.Fprint(w, token.Text)


### PR DESCRIPTION
This PR introduces the Alda code formatter as part of the complete decompiler. 

Code formatters can be arbitrarily complex, with entire papers dedicated to the study of how and where to insert spaces and new lines. 

Code formatters can also support customization. 

For now, we will aim to create a simple formatter that can be expanded upon as requested in the future. 