### PR TITLE
#321 Validate MIDI note range

### DIFF
--- a/client/model/note.go
+++ b/client/model/note.go
@@ -127,6 +127,10 @@ func addNoteOrRest(score *Score, noteOrRest ScoreUpdate) error {
 				)
 
 				if midiNote < 0 || midiNote > 127 {
+					log.Debug().
+						Int("midiNote", int(midiNote)).
+						Msg("Midi note out of range.")
+
 					return help.UserFacingErrorf("Midi note out of the 0-127 range. Input note: %d", midiNote)
 				}
 

--- a/client/model/note.go
+++ b/client/model/note.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"alda.io/client/help"
 	"alda.io/client/json"
 	log "alda.io/client/logging"
 )
@@ -124,6 +125,10 @@ func addNoteOrRest(score *Score, noteOrRest ScoreUpdate) error {
 				midiNote := note.Pitch.CalculateMidiNote(
 					part.Octave, part.KeySignature, part.Transposition,
 				)
+
+				if midiNote < 0 || midiNote > 127 {
+					return help.UserFacingErrorf("Midi note out of the 0-127 range. Input note: %d", midiNote)
+				}
 
 				noteEvent := NoteEvent{
 					Part:            part.origin,


### PR DESCRIPTION
Added validation for midi note range in note.go. We raise a UserFacingError if midi note is > 0 or < 127 and log the event.