### PR TITLE
Issue #348 - :parts

### DIFF
--- a/client/repl/client.go
+++ b/client/repl/client.go
@@ -257,6 +257,37 @@ file into the REPL server.`,
 			},
 		},
 
+		"parts": {
+			helpSummary: "Displays instrument currently in use.",
+			run: func(client *Client, argsString string) error {
+				// Read and parse score information
+				scoreData, err := client.scoreData()
+					if err != nil {
+						return err
+					}
+
+				parts := scoreData.Search("parts")
+				if parts.Data() == nil {
+					return fmt.Errorf("Server response missing information about parts.")
+				}
+			
+				// Print instrument Names and IDs from current score
+				if len(parts.ChildrenMap()) == 0 {
+					fmt.Println("No instruments in current score.")
+				} else {
+					fmt.Println("Parts:")
+					for id, part := range parts.ChildrenMap() {
+						fmt.Printf(
+							"  %s (%s)\n",
+							id,
+							part.Search("stock-instrument").Data(),
+						)
+					}
+				}
+				return nil
+			},
+		},
+
 		"play": {
 			helpSummary: "Plays the current score.",
 			helpDetails: `Can take optional ` + "`from`" + `and ` + "`to`" +

--- a/client/repl/client.go
+++ b/client/repl/client.go
@@ -260,7 +260,7 @@ file into the REPL server.`,
 		"parts": {
 			helpSummary: "Displays instrument currently in use.",
 			run: func(client *Client, argsString string) error {
-				// Read and parse score information
+				// Read and parse score to extract instrument information 
 				scoreData, err := client.scoreData()
 					if err != nil {
 						return err


### PR DESCRIPTION
Hello Dave,

I added the ":parts" command mentioned within the REPL feature suggestions of issue #348. 

I referenced other repl command handlers, especially that for ":score," to safely parse the score data and access the map of instruments. 

Please let me know if there are any changes you would like to see (or anywhere that I can add tests). 
I also wanted to ask about the grouping of instruments; as of now, the command simply prints out all instruments within the current score, but the original description mentions a format that 'shows if the instruments are in a group'. 
