### PR TITLE
Add `describe` operation to REPL server doc

### DIFF
--- a/doc/alda-repl-server-api.adoc
+++ b/doc/alda-repl-server-api.adoc
@@ -23,6 +23,22 @@ $ alda repl --client --port 34223 --message '{"op": "score-text"}'
 
 == Operations
 
+=== `describe`
+
+Returns information on the Alda REPL server.
+
+Required parameters::
+{blank}
+
+Optional parameters::
+{blank}
+
+Returns::
+* `ops` - the operations available on the Alda REPL server
+* `problems` if there were any
+* `status`
+* `versions` - Alda version information
+
 === `eval-and-play`
 
 Parses the provided input in the context of the current score, updates the score


### PR DESCRIPTION
I have noticed that the `describe` operation is not included in the REPL server doc. Any reasons for not adding it?