### PR TITLE
Fix issue #321 - Validate MIDI Note range

### DIFF
--- a/client/model/note.go
+++ b/client/model/note.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"alda.io/client/help"
 	"alda.io/client/json"
 	log "alda.io/client/logging"
 )
@@ -122,6 +123,10 @@ func addNoteOrRest(score *Score, noteOrRest ScoreUpdate) error {
 				midiNote := noteOrRest.Pitch.CalculateMidiNote(
 					part.Octave, part.KeySignature, part.Transposition,
 				)
+				
+				if midiNote < 0 || midiNote > 127 {
+					return help.UserFacingErrorf("Midi note out of the 0-127 range. Input note: %d", midiNote)
+				}
 
 				noteEvent := NoteEvent{
 					Part:            part.origin,

--- a/client/model/notes_test.go
+++ b/client/model/notes_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	_ "alda.io/client/testing"
@@ -597,6 +598,25 @@ func TestNotes(t *testing.T) {
 			expectations: []scoreUpdateExpectation{
 				expectNoteOffsets(12345),
 				expectNoteDurations(1500),
+			},
+		},
+		scoreUpdateTestCase{
+			// alda play -c 'piano: o10 c' - Midi note out of range
+			label: "C note with MIDI value out of range",
+			updates: []ScoreUpdate{
+				PartDeclaration{Names: []string{"piano"}},
+				AttributeUpdate{PartUpdate: OctaveSet{OctaveNumber: 10}},
+				Note{
+					Pitch: LetterAndAccidentals{NoteLetter: C},
+				},
+			},
+			errorExpectations: []scoreUpdateErrorExpectation{
+				func(err error) error {
+					if !strings.Contains(err.Error(), "Midi note out of the 0-127 range") {
+						return err
+					}
+					return nil
+				},
 			},
 		},
 	)


### PR DESCRIPTION
Added an error when MIDI is out of the range 0-127 and added a test case checking the error is thrown.