### PR TITLE
ASTNode Generation from []ScoreUpdate's

### DIFF
--- a/client/doc/notes/interaction-modes.adoc
+++ b/client/doc/notes/interaction-modes.adoc
@@ -76,7 +76,7 @@ development and live coding.
 * One use case is for each collaborator to work on a separate part.
 ** It might be useful for the REPL client session (or text editor plugin, etc.)
 to keep track of which instrument the collaborator used last, and explicitly
-prepend that part declaration (e.g. `bass:`) to the beginning of every message
+prepend that part declaration (e.g. `piano:`) to the beginning of every message
 to the server.
 *** In an interactive Alda REPL client session, we could actually make the part
 declaration an editable part of the message, so that the user could see that the

--- a/client/model/key.go
+++ b/client/model/key.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"math"
+	"strings"
 
 	"alda.io/client/json"
 )
@@ -44,6 +45,30 @@ const (
 //
 //   {B: [flat, flat], G: [sharp], E: [flat]}
 type KeySignature map[NoteLetter][]Accidental
+
+func (ks KeySignature) String() string {
+	laas := []string{}
+
+	for note, accidentals := range ks {
+		laa := strings.Builder{}
+		laa.WriteRune(rune(note + 'a'))
+
+		for _, acc := range accidentals {
+			switch acc {
+			case Flat:
+				laa.WriteString("-")
+			case Natural:
+				laa.WriteString("_")
+			case Sharp:
+				laa.WriteString("+")
+			}
+		}
+
+		laas = append(laas, laa.String())
+	}
+
+	return strings.Join(laas, " ")
+}
 
 // JSON implements RepresentableAsJSON.JSON.
 func (ks KeySignature) JSON() *json.Container {

--- a/client/parser/barlines_test.go
+++ b/client/parser/barlines_test.go
@@ -13,7 +13,7 @@ func TestBarlines(t *testing.T) {
 		parseTestCase{
 			label: "simple use of barlines",
 			given: "violin: c d | e f | g a",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"violin"}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.D}},
@@ -28,7 +28,7 @@ func TestBarlines(t *testing.T) {
 		parseTestCase{
 			label: "a note tied over many barlines",
 			given: "marimba: c1|~1|~1~|1|~1~|2.",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"marimba"}},
 				model.Note{
 					Pitch: model.LetterAndAccidentals{NoteLetter: model.C},

--- a/client/parser/chords_test.go
+++ b/client/parser/chords_test.go
@@ -13,7 +13,7 @@ func TestChords(t *testing.T) {
 		parseTestCase{
 			label: "simple chord",
 			given: "c/e/g",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Chord{
 					Events: []model.ScoreUpdate{
 						model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
@@ -26,7 +26,7 @@ func TestChords(t *testing.T) {
 		parseTestCase{
 			label: "chord that includes a rest",
 			given: "c1/>e2/g4/r8",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Chord{
 					Events: []model.ScoreUpdate{
 						model.Note{
@@ -68,7 +68,7 @@ func TestChords(t *testing.T) {
 		parseTestCase{
 			label: "chord that includes a dotted note",
 			given: "b>/d/f2.",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Chord{
 					Events: []model.ScoreUpdate{
 						model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.B}},
@@ -89,7 +89,7 @@ func TestChords(t *testing.T) {
 		parseTestCase{
 			label: "chord, then octave down, then note",
 			given: "c/e/g < c",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Chord{
 					Events: []model.ScoreUpdate{
 						model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},

--- a/client/parser/comments_test.go
+++ b/client/parser/comments_test.go
@@ -15,7 +15,7 @@ func TestComments(t *testing.T) {
 			given: `piano: c
 			# d
 			e`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"piano"}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.E}},
@@ -25,7 +25,7 @@ func TestComments(t *testing.T) {
 			label: "comment at the end of a line",
 			given: `piano: c # d
 			e`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"piano"}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.E}},
@@ -35,7 +35,7 @@ func TestComments(t *testing.T) {
 			label: "comment without a leading space",
 			given: `piano: c #d
 			e`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"piano"}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.E}},

--- a/client/parser/cram_test.go
+++ b/client/parser/cram_test.go
@@ -13,7 +13,7 @@ func TestCram(t *testing.T) {
 		parseTestCase{
 			label: "cram expression",
 			given: "{c d e}",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Cram{
 					Events: []model.ScoreUpdate{
 						model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
@@ -26,7 +26,7 @@ func TestCram(t *testing.T) {
 		parseTestCase{
 			label: "cram expression with specified duration",
 			given: "{c d e}2",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Cram{
 					Events: []model.ScoreUpdate{
 						model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},

--- a/client/parser/duration_test.go
+++ b/client/parser/duration_test.go
@@ -20,49 +20,49 @@ func TestDurations(t *testing.T) {
 		parseTestCase{
 			label: "Note with integer note length",
 			given: "c2",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(model.NoteLength{Denominator: 2}),
 			},
 		},
 		parseTestCase{
 			label: "Note with fractional note length",
 			given: "c0.5",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(model.NoteLength{Denominator: 0.5}),
 			},
 		},
 		parseTestCase{
 			label: "Note with integer note length and dots",
 			given: "c2..",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(model.NoteLength{Denominator: 2, Dots: 2}),
 			},
 		},
 		parseTestCase{
 			label: "Note with fractional note length and dots",
 			given: "c0.5..",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(model.NoteLength{Denominator: 0.5, Dots: 2}),
 			},
 		},
 		parseTestCase{
 			label: "Note with duration in milliseconds",
 			given: "c450ms",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(model.NoteLengthMs{Quantity: 450}),
 			},
 		},
 		parseTestCase{
 			label: "Note with duration in seconds",
 			given: "c2s",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(model.NoteLengthMs{Quantity: 2000}),
 			},
 		},
 		parseTestCase{
 			label: "Note with tied integer note lengths",
 			given: "c1~2~4",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(
 					model.NoteLength{Denominator: 1},
 					model.NoteLength{Denominator: 2},
@@ -73,7 +73,7 @@ func TestDurations(t *testing.T) {
 		parseTestCase{
 			label: "Note with tied integer/fractional note lengths",
 			given: "c1.5~2.5~4",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(
 					model.NoteLength{Denominator: 1.5},
 					model.NoteLength{Denominator: 2.5},
@@ -84,7 +84,7 @@ func TestDurations(t *testing.T) {
 		parseTestCase{
 			label: "Note with tied millisecond note lengths",
 			given: "c500ms~350ms",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(
 					model.NoteLengthMs{Quantity: 500},
 					model.NoteLengthMs{Quantity: 350},
@@ -94,7 +94,7 @@ func TestDurations(t *testing.T) {
 		parseTestCase{
 			label: "Note with various tied note lengths",
 			given: "c5s~4~350ms~0.5",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(
 					model.NoteLengthMs{Quantity: 5000},
 					model.NoteLength{Denominator: 4},
@@ -106,7 +106,7 @@ func TestDurations(t *testing.T) {
 		parseTestCase{
 			label: "Slurred note with implicit duration",
 			given: "c~",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{
 					Pitch:   model.LetterAndAccidentals{NoteLetter: model.C},
 					Slurred: true,
@@ -116,7 +116,7 @@ func TestDurations(t *testing.T) {
 		parseTestCase{
 			label: "Slurred note with integer note length",
 			given: "c4~",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{
 					Pitch: model.LetterAndAccidentals{NoteLetter: model.C},
 					Duration: model.Duration{
@@ -131,7 +131,7 @@ func TestDurations(t *testing.T) {
 		parseTestCase{
 			label: "Slurred note with millisecond note length",
 			given: "c420ms~",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{
 					Pitch: model.LetterAndAccidentals{NoteLetter: model.C},
 					Duration: model.Duration{

--- a/client/parser/event_sequences_test.go
+++ b/client/parser/event_sequences_test.go
@@ -20,21 +20,21 @@ func TestEventSequences(t *testing.T) {
 		parseTestCase{
 			label: "empty event sequence",
 			given: "[]",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				eventSequence(),
 			},
 		},
 		parseTestCase{
 			label: "empty event sequence with internal whitespace",
 			given: "[    ]",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				eventSequence(),
 			},
 		},
 		parseTestCase{
 			label: "event sequence with some notes and rests",
 			given: "[c d c r]",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				eventSequence(
 					model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 					model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.D}},
@@ -46,7 +46,7 @@ func TestEventSequences(t *testing.T) {
 		parseTestCase{
 			label: "event sequence with some notes, rests and a little right padding",
 			given: "[c d c r ]",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				eventSequence(
 					model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 					model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.D}},
@@ -58,7 +58,7 @@ func TestEventSequences(t *testing.T) {
 		parseTestCase{
 			label: "event sequence with some notes and a chord",
 			given: "[ c d e f c/e/g ]",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				eventSequence(
 					model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 					model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.D}},
@@ -77,7 +77,7 @@ func TestEventSequences(t *testing.T) {
 		parseTestCase{
 			label: "nested event sequence with some notes",
 			given: "[c d [e f] g]",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				eventSequence(
 					model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 					model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.D}},
@@ -92,7 +92,7 @@ func TestEventSequences(t *testing.T) {
 		parseTestCase{
 			label: "event sequence containing voices",
 			given: "[V1: e b d V2: a c f]",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				eventSequence(
 					model.VoiceMarker{VoiceNumber: 1},
 					model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.E}},
@@ -108,7 +108,7 @@ func TestEventSequences(t *testing.T) {
 		parseTestCase{
 			label: "event sequence containing a note",
 			given: "[c1]",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				eventSequence(
 					model.Note{
 						Pitch: model.LetterAndAccidentals{NoteLetter: model.C},
@@ -124,7 +124,7 @@ func TestEventSequences(t *testing.T) {
 		parseTestCase{
 			label: "event sequence containing a note w/ duration in seconds",
 			given: "[c1s]",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				eventSequence(
 					model.Note{
 						Pitch: model.LetterAndAccidentals{NoteLetter: model.C},

--- a/client/parser/gen.go
+++ b/client/parser/gen.go
@@ -1,0 +1,441 @@
+package parser
+
+import (
+	"alda.io/client/model"
+	"fmt"
+)
+
+// withDuration returns the same ASTNode with an added DurationNode child if the
+// provided model.Duration is non-empty.
+func withDuration(node ASTNode, duration model.Duration) (ASTNode, error) {
+	if len(duration.Components) == 0 {
+		return node, nil
+	}
+
+	durationNode := ASTNode{Type: DurationNode}
+
+	for _, component := range duration.Components {
+		switch c := component.(type) {
+
+		case model.Barline:
+			durationNode.Children = append(durationNode.Children, ASTNode{
+				Type: BarlineNode,
+			})
+
+		case model.NoteLength:
+			noteLength := ASTNode{Type: NoteLengthNode, Children: []ASTNode{{
+				Type:    DenominatorNode,
+				Literal: c.Denominator,
+			}}}
+			if c.Dots > 0 {
+				noteLength.Children = append(noteLength.Children, ASTNode{
+					Type:    DotsNode,
+					Literal: c.Dots,
+				})
+			}
+			durationNode.Children = append(durationNode.Children, noteLength)
+
+		case model.NoteLengthMs:
+			durationNode.Children = append(durationNode.Children, ASTNode{
+				Type:    NoteLengthMsNode,
+				Literal: c.Quantity,
+			})
+
+		default:
+			// model.NoteLengthBeats - only generated within lisp
+			return ASTNode{}, fmt.Errorf(
+				"unexpected DurationComponent during AST generation: %#v", c,
+			)
+
+		}
+	}
+
+	node.Children = append(node.Children, durationNode)
+	return node, nil
+}
+
+// mapIsolatedUpdate maps a single isolated model.ScoreUpdate to ASTNode.
+// Holistic updates that require "re-construction" are handled upstream:
+// 	1. Parts in mapTopLevel.
+// 	2. model.VoiceMarker, model.VoiceGroupEndMarker in mapInnerEvents.
+func mapIsolatedUpdate(scoreUpdate model.ScoreUpdate) (ASTNode, error) {
+	switch update := scoreUpdate.(type) {
+
+	case model.AtMarker:
+		return ASTNode{Type: AtMarkerNode, Literal: update.Name}, nil
+
+	case model.AttributeUpdate:
+		switch pu := update.PartUpdate.(type) {
+
+		// The following have direct ASTNode representations
+		case model.OctaveSet:
+			return ASTNode{Type: OctaveSetNode, Literal: pu.OctaveNumber}, nil
+
+		case model.OctaveUp:
+			return ASTNode{Type: OctaveUpNode}, nil
+
+		case model.OctaveDown:
+			return ASTNode{Type: OctaveDownNode}, nil
+
+		// Most part updates must be formatted via lisp.
+		// We handle the subset that can be generated via MusicXML import.
+		// TODO: handle generating all possible part updates into lisp.
+		case model.DynamicMarking:
+			return ASTNode{Type: LispListNode, Children: []ASTNode{{
+				Type: LispSymbolNode,
+				Literal: pu.Marking,
+			}}}, nil
+
+		case model.KeySignatureSet:
+			// Note: we arbitrarily select one of multiple lisp names.
+			// This is ok for now, but would make generated ASTs different from
+			// parsed ones (different LispSymbolNode Literal) if ASTNode.Updates
+			// ever directly outputs evaluated lisp.
+			return ASTNode{Type: LispListNode, Children: []ASTNode{
+				{
+					Type: LispSymbolNode,
+					Literal: "key-signature",
+				},
+				{
+					Type: LispStringNode,
+					Literal: pu.KeySignature.String(),
+				},
+			}}, nil
+
+		case model.TranspositionSet:
+			return ASTNode{Type: LispListNode, Children: []ASTNode{
+				{
+					Type: LispSymbolNode,
+					Literal: "transpose",
+				},
+				{
+					Type: LispNumberNode,
+					Literal: pu.Semitones,
+				},
+			}}, nil
+
+		default:
+			return ASTNode{}, fmt.Errorf(
+				"unexpected PartUpdate type during AST generation: %#v", pu,
+			)
+
+		}
+
+	case model.Barline:
+		return ASTNode{Type: BarlineNode}, nil
+
+	case model.Chord:
+		children, err := mapInnerEvents(update.Events)
+		if err != nil {
+			return ASTNode{}, err
+		}
+		return ASTNode{Type: ChordNode, Children: children}, nil
+
+	case model.Cram:
+		children, err := mapInnerEvents(update.Events)
+		if err != nil {
+			return ASTNode{}, err
+		}
+		cram := ASTNode{Type: CramNode, Children: []ASTNode{{
+			Type:     EventSequenceNode,
+			Children: children,
+		}}}
+		return withDuration(cram, update.Duration)
+
+	case model.EventSequence:
+		children, err := mapInnerEvents(update.Events)
+		if err != nil {
+			return ASTNode{}, err
+		}
+
+		if children == nil {
+			children = []ASTNode{}
+		}
+		return ASTNode{Type: EventSequenceNode, Children: children}, nil
+
+	case model.LispList:
+		var lispFormToNode func(model.LispForm) (ASTNode, error)
+		lispFormToNode = func(lispForm model.LispForm) (ASTNode, error) {
+			switch l := lispForm.(type) {
+
+			case model.LispList:
+				lispList := ASTNode{Type: LispListNode}
+				for _, element := range l.Elements {
+					node, err := lispFormToNode(element)
+					if err != nil {
+						return ASTNode{}, err
+					}
+					lispList.Children = append(lispList.Children, node)
+				}
+				return lispList, nil
+
+			case model.LispNumber:
+				return ASTNode{Type: LispNumberNode, Literal: l.Value}, nil
+
+			case model.LispQuotedForm:
+				node, err := lispFormToNode(l.Form)
+				if err != nil {
+					return ASTNode{}, err
+				}
+				return ASTNode{
+					Type:     LispQuotedFormNode,
+					Children: []ASTNode{node},
+				}, nil
+
+			case model.LispString:
+				return ASTNode{Type: LispStringNode, Literal: l.Value}, nil
+
+			case model.LispSymbol:
+				return ASTNode{Type: LispSymbolNode, Literal: l.Name}, nil
+
+			default:
+				return ASTNode{}, fmt.Errorf(
+					"unexpected LispForm type during AST gen: %#v", l,
+				)
+
+			}
+		}
+		return lispFormToNode(update)
+
+	case model.Marker:
+		return ASTNode{Type: MarkerNode, Literal: update.Name}, nil
+
+	case model.Note:
+		note := ASTNode{Type: NoteNode}
+
+		switch pitch := update.Pitch.(type) {
+
+		case model.LetterAndAccidentals:
+			laa := ASTNode{Type: NoteLetterAndAccidentalsNode}
+
+			laa.Children = append(laa.Children, ASTNode{
+				Type:    NoteLetterNode,
+				Literal: rune(pitch.NoteLetter + 'a'),
+			})
+
+			if len(pitch.Accidentals) > 0 {
+				var acc []ASTNode
+				for _, accidental := range pitch.Accidentals {
+					switch accidental {
+					case model.Flat:
+						acc = append(acc, ASTNode{Type: FlatNode})
+					case model.Natural:
+						acc = append(acc, ASTNode{Type: NaturalNode})
+					case model.Sharp:
+						acc = append(acc, ASTNode{Type: SharpNode})
+					}
+				}
+				laa.Children = append(laa.Children, ASTNode{
+					Type:     NoteAccidentalsNode,
+					Children: acc,
+				})
+			}
+
+			note.Children = append(note.Children, laa)
+
+		default:
+			// model.MidiNoteNumber - never parsed from Alda code, only used:
+			// 	1. with model.LispPitch (unnecessary to handle here)
+			// 	2. by MusicXML importer (removed during optimization)
+			return ASTNode{}, fmt.Errorf(
+				"unexpected PitchIdentifier type during AST gen: %#v", pitch,
+			)
+
+		}
+
+		note, err := withDuration(note, update.Duration)
+		if err != nil {
+			return ASTNode{}, err
+		}
+
+		if update.Slurred {
+			note.Children = append(note.Children, ASTNode{Type: TieNode})
+		}
+
+		return note, nil
+
+	case model.OnRepetitions:
+		node, err := mapIsolatedUpdate(update.Event)
+		if err != nil {
+			return ASTNode{}, err
+		}
+
+		repetitions := ASTNode{Type: RepetitionsNode}
+		for _, rep := range update.Repetitions {
+			repetitions.Children = append(repetitions.Children, ASTNode{
+				Type: RepetitionRangeNode,
+				Children: []ASTNode{
+					{Type: FirstRepetitionNode, Literal: rep.First},
+					{Type: LastRepetitionNode, Literal: rep.Last},
+				},
+			})
+		}
+
+		return ASTNode{
+			Type:     OnRepetitionsNode,
+			Children: []ASTNode{node, repetitions},
+		}, nil
+
+	case model.Repeat:
+		node, err := mapIsolatedUpdate(update.Event)
+		if err != nil {
+			return ASTNode{}, err
+		}
+		return ASTNode{Type: RepeatNode, Children: []ASTNode{
+			node,
+			{Type: TimesNode, Literal: update.Times},
+		}}, nil
+
+	case model.Rest:
+		return withDuration(ASTNode{Type: RestNode}, update.Duration)
+
+	case model.VariableDefinition:
+		children, err := mapInnerEvents(update.Events)
+		if err != nil {
+			return ASTNode{}, err
+		}
+		return ASTNode{Type: VariableDefinitionNode, Children: []ASTNode{
+			{Type: VariableNameNode, Literal: update.VariableName},
+			{Type: EventSequenceNode, Children: children},
+		}}, nil
+
+	case model.VariableReference:
+		return ASTNode{
+			Type:    VariableReferenceNode,
+			Literal: update.VariableName,
+		}, nil
+
+	default:
+		// PartDeclaration, VoiceMarker, VoiceGroupEndMarker - handled upstream
+		// GlobalAttributeUpdate - only generated within Lisp
+		// LispNil - should never exist here
+		return ASTNode{}, fmt.Errorf(
+			"unexpected ScoreUpdate type during AST gen: %#v", update,
+		)
+
+	}
+}
+
+// mapInnerEvents maps a group of inner updates to a group of ASTNode's.
+// Parts are ignored and handled upstream in mapTopLevel.
+// Voices are handled by identifying model.VoiceMarker then generating
+// subsequent nodes within an overarching VoiceGroupNode.
+func mapInnerEvents(updates []model.ScoreUpdate) ([]ASTNode, error) {
+	dummyNode := ASTNode{Children: []ASTNode{}}
+
+	var currentVoiceGroup *ASTNode
+	currentNode := &dummyNode
+
+	for _, update := range updates {
+		switch u := update.(type) {
+
+		case model.VoiceMarker:
+			if currentVoiceGroup == nil {
+				currentVoiceGroup = &ASTNode{Type: VoiceGroupNode}
+			}
+			currentVoiceGroup.Children = append(currentVoiceGroup.Children,
+				ASTNode{Type: VoiceNode, Children: []ASTNode{
+					{Type: VoiceNumberNode, Literal: u.VoiceNumber},
+					{Type: EventSequenceNode},
+				}})
+			currIndex := len(currentVoiceGroup.Children) - 1
+			currentNode = &currentVoiceGroup.Children[currIndex].Children[1]
+
+		case model.VoiceGroupEndMarker:
+			currentVoiceGroup.Children = append(currentVoiceGroup.Children,
+				ASTNode{Type: VoiceGroupEndMarkerNode},
+			)
+			dummyNode.Children = append(dummyNode.Children, *currentVoiceGroup)
+			currentVoiceGroup = nil
+			currentNode = &dummyNode
+
+		default:
+			node, err := mapIsolatedUpdate(u)
+			if err != nil {
+				return []ASTNode{}, err
+			}
+			currentNode.Children = append(currentNode.Children, node)
+
+		}
+	}
+
+	if currentVoiceGroup != nil {
+		dummyNode.Children = append(dummyNode.Children, *currentVoiceGroup)
+	}
+
+	return dummyNode.Children, nil
+}
+
+// mapTopLevel maps a top level group of updates to a RootNode.
+// mapTopLevel handles PartNode and ImplicitPartNode, then calls mapInnerEvents.
+func mapTopLevel(updates []model.ScoreUpdate) (ASTNode, error) {
+	root := ASTNode{Type: RootNode}
+
+	// Construct PartNodes by iterating backwards
+	currentPartEndIndex := len(updates)
+	for i := len(updates) - 1; i >= 0; i-- {
+		if partDeclarationUpdate, ok := updates[i].(model.PartDeclaration); ok {
+			partDecl := ASTNode{Type: PartDeclarationNode}
+
+			partNames := ASTNode{Type: PartNamesNode}
+			for _, name := range partDeclarationUpdate.Names {
+				partNames.Children = append(partNames.Children, ASTNode{
+					Type:    PartNameNode,
+					Literal: name,
+				})
+			}
+			partDecl.Children = append(partDecl.Children, partNames)
+
+			if len(partDeclarationUpdate.Alias) > 0 {
+				partDecl.Children = append(partDecl.Children, ASTNode{
+					Type:    PartAliasNode,
+					Literal: partDeclarationUpdate.Alias,
+				})
+			}
+
+			events, err := mapInnerEvents(
+				updates[i+1 : currentPartEndIndex],
+			)
+			if err != nil {
+				return ASTNode{}, err
+			}
+
+			part := ASTNode{Type: PartNode, Children: []ASTNode{
+				partDecl,
+				{Type: EventSequenceNode, Children: events},
+			}}
+			root.Children = append([]ASTNode{part}, root.Children...)
+			currentPartEndIndex = i
+		}
+	}
+
+	// Any remaining prefix is put into an ImplicitPartNode
+	if currentPartEndIndex > 0 {
+		nodes, err := mapInnerEvents(updates[0:currentPartEndIndex])
+		if err != nil {
+			return ASTNode{}, err
+		}
+
+		implicitPart := ASTNode{Type: ImplicitPartNode, Children: []ASTNode{{
+			Type:     EventSequenceNode,
+			Children: nodes,
+		}}}
+		root.Children = append([]ASTNode{implicitPart}, root.Children...)
+	}
+
+	return root, nil
+}
+
+// GenerateASTFromScoreUpdates generates an ASTNode from []model.ScoreUpdate.
+// This is a direct inverse of ASTNode.Updates with the exception of
+// model.AldaSourceContext which is currently ignored because:
+// 	1. ASTNode.Updates is lossy and drops model.AldaSourceContext converting
+//	   DurationNode -> model.Duration. This is the only lost info and can be
+//	   remedied by adding model.AldaSourceContext to model.DurationComponent.
+// 	2. ASTNode generation currently doesn't require model.AldaSourceContext.
+//	   It can always be obtained from the original Alda file.
+//     The current use case is MusicXML import, which generates
+//     model.ScoreUpdate's without model.AldaSourceContext.
+func GenerateASTFromScoreUpdates(updates []model.ScoreUpdate) (ASTNode, error) {
+	return mapTopLevel(updates)
+}

--- a/client/parser/lisp_test.go
+++ b/client/parser/lisp_test.go
@@ -37,35 +37,35 @@ func TestLisp(t *testing.T) {
 		parseTestCase{
 			label: "attribute change with no value",
 			given: "(fff)",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				lispList(lispSymbol("fff")),
 			},
 		},
 		parseTestCase{
 			label: "attribute change with number value",
 			given: "(volume 50)",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				lispList(lispSymbol("volume"), lispNumber(50)),
 			},
 		},
 		parseTestCase{
 			label: "attribute change with string value",
 			given: `(key-signature "f+ c+ g+")`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				lispList(lispSymbol("key-signature"), lispString("f+ c+ g+")),
 			},
 		},
 		parseTestCase{
 			label: "global attribute change",
 			given: "(tempo! 200)",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				lispList(lispSymbol("tempo!"), lispNumber(200)),
 			},
 		},
 		parseTestCase{
 			label: "attribute change with quoted list argument",
 			given: "(key-sig '(a major))",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				lispList(
 					lispSymbol("key-sig"),
 					lispQuotedList(lispSymbol("a"), lispSymbol("major")),
@@ -75,7 +75,7 @@ func TestLisp(t *testing.T) {
 		parseTestCase{
 			label: "attribute change with quoted nested list argument",
 			given: "(key-signature '(e (flat) b (flat)))",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				lispList(
 					lispSymbol("key-signature"),
 					lispQuotedList(

--- a/client/parser/markers_test.go
+++ b/client/parser/markers_test.go
@@ -11,15 +11,18 @@ func TestMarkers(t *testing.T) {
 		t,
 		parseTestCase{
 			label: "marker",
-			given: "%chorus",
-			expect: []model.ScoreUpdate{
+			given: "piano: %chorus",
+			expectUpdates: []model.ScoreUpdate{
+				model.PartDeclaration{Names: []string{"piano"}},
 				model.Marker{Name: "chorus"},
 			},
 		},
 		parseTestCase{
 			label: "at marker",
-			given: "@verse-1",
-			expect: []model.ScoreUpdate{
+			given: "piano: %verse-1 @verse-1",
+			expectUpdates: []model.ScoreUpdate{
+				model.PartDeclaration{Names: []string{"piano"}},
+				model.Marker{Name: "verse-1"},
 				model.AtMarker{Name: "verse-1"},
 			},
 		},

--- a/client/parser/notes_test.go
+++ b/client/parser/notes_test.go
@@ -13,14 +13,14 @@ func TestNotes(t *testing.T) {
 		parseTestCase{
 			label: "note with implicit duration",
 			given: "c",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 			},
 		},
 		parseTestCase{
 			label: "note with explicit duration",
 			given: "c4",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{
 					Pitch: model.LetterAndAccidentals{NoteLetter: model.C},
 					Duration: model.Duration{
@@ -34,7 +34,7 @@ func TestNotes(t *testing.T) {
 		parseTestCase{
 			label: "sharp note",
 			given: "c+",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{
 					Pitch: model.LetterAndAccidentals{
 						NoteLetter:  model.C,
@@ -46,7 +46,7 @@ func TestNotes(t *testing.T) {
 		parseTestCase{
 			label: "flat note",
 			given: "b-",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{
 					Pitch: model.LetterAndAccidentals{
 						NoteLetter:  model.B,
@@ -58,7 +58,7 @@ func TestNotes(t *testing.T) {
 		parseTestCase{
 			label: "double sharp note",
 			given: "c++",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{
 					Pitch: model.LetterAndAccidentals{
 						NoteLetter:  model.C,
@@ -70,7 +70,7 @@ func TestNotes(t *testing.T) {
 		parseTestCase{
 			label: "double flat note",
 			given: "b--",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{
 					Pitch: model.LetterAndAccidentals{
 						NoteLetter:  model.B,
@@ -82,14 +82,14 @@ func TestNotes(t *testing.T) {
 		parseTestCase{
 			label: "rest with implicit duration",
 			given: "r",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Rest{},
 			},
 		},
 		parseTestCase{
 			label: "rest with explicit duration",
 			given: "r1",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Rest{
 					Duration: model.Duration{
 						Components: []model.DurationComponent{

--- a/client/parser/octaves_test.go
+++ b/client/parser/octaves_test.go
@@ -25,24 +25,24 @@ func TestOctaves(t *testing.T) {
 	executeParseTestCases(
 		t,
 		parseTestCase{
-			label:  "octave up",
-			given:  ">",
-			expect: []model.ScoreUpdate{octaveUp()},
+			label:         "octave up",
+			given:         ">",
+			expectUpdates: []model.ScoreUpdate{octaveUp()},
 		},
 		parseTestCase{
-			label:  "octave down",
-			given:  "<",
-			expect: []model.ScoreUpdate{octaveDown()},
+			label:         "octave down",
+			given:         "<",
+			expectUpdates: []model.ScoreUpdate{octaveDown()},
 		},
 		parseTestCase{
-			label:  "octave set",
-			given:  "o5",
-			expect: []model.ScoreUpdate{octaveSet(5)},
+			label:         "octave set",
+			given:         "o5",
+			expectUpdates: []model.ScoreUpdate{octaveSet(5)},
 		},
 		parseTestCase{
 			label: "multi-octave up",
 			given: ">>>",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				octaveUp(),
 				octaveUp(),
 				octaveUp(),
@@ -51,7 +51,7 @@ func TestOctaves(t *testing.T) {
 		parseTestCase{
 			label: "multi-octave down",
 			given: "<<<",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				octaveDown(),
 				octaveDown(),
 				octaveDown(),
@@ -60,7 +60,7 @@ func TestOctaves(t *testing.T) {
 		parseTestCase{
 			label: "octave fish ><>",
 			given: "><>",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				octaveUp(),
 				octaveDown(),
 				octaveUp(),
@@ -69,7 +69,7 @@ func TestOctaves(t *testing.T) {
 		parseTestCase{
 			label: "octave up immediately followed by note",
 			given: ">c",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				octaveUp(),
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 			},
@@ -77,7 +77,7 @@ func TestOctaves(t *testing.T) {
 		parseTestCase{
 			label: "octave down immediately followed by note",
 			given: "<c",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				octaveDown(),
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 			},
@@ -85,7 +85,7 @@ func TestOctaves(t *testing.T) {
 		parseTestCase{
 			label: "note immediately followed by octave up",
 			given: "c>",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				octaveUp(),
 			},
@@ -93,7 +93,7 @@ func TestOctaves(t *testing.T) {
 		parseTestCase{
 			label: "note immediately followed by octave down",
 			given: "c<",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				octaveDown(),
 			},
@@ -101,7 +101,7 @@ func TestOctaves(t *testing.T) {
 		parseTestCase{
 			label: "note sandwiched between octave up/down",
 			given: ">c<",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				octaveUp(),
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				octaveDown(),

--- a/client/parser/parser.go
+++ b/client/parser/parser.go
@@ -10,13 +10,12 @@ import (
 	"alda.io/client/color"
 	"alda.io/client/help"
 	log "alda.io/client/logging"
-	model "alda.io/client/model"
+	"alda.io/client/model"
 )
 
 type parser struct {
 	filename string
 	input    []Token
-	updates  []model.ScoreUpdate
 	current  int
 	// When true, source context is _not_ included in parsed tokens. This is
 	// useful for testing, e.g. for checking the equality of a list of expected
@@ -44,7 +43,6 @@ func newParser(filename string, tokens []Token, opts ...parseOption) *parser {
 	parser := &parser{
 		filename: filename,
 		input:    tokens,
-		updates:  []model.ScoreUpdate{},
 		current:  0,
 	}
 
@@ -966,7 +964,7 @@ func (p *parser) voiceGroup() (ASTNode, error) {
 
 	voiceGroupNode := ASTNode{
 		Type:          VoiceGroupNode,
-		SourceContext: firstVoiceMarkerToken.sourceContext,
+		SourceContext: p.sourceContext(firstVoiceMarkerToken),
 		Children:      []ASTNode{},
 	}
 

--- a/client/parser/parts_test.go
+++ b/client/parser/parts_test.go
@@ -12,9 +12,9 @@ func TestParts(t *testing.T) {
 		t,
 		parseTestCase{
 			label: "part with single name",
-			given: "theremin: c d e",
-			expect: []model.ScoreUpdate{
-				model.PartDeclaration{Names: []string{"theremin"}},
+			given: "piano: c d e",
+			expectUpdates: []model.ScoreUpdate{
+				model.PartDeclaration{Names: []string{"piano"}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.D}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.E}},
@@ -23,7 +23,7 @@ func TestParts(t *testing.T) {
 		parseTestCase{
 			label: "part with single name and an alias",
 			given: `harmonica "bob": c d e`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"harmonica"}, Alias: "bob"},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.D}},
@@ -33,7 +33,7 @@ func TestParts(t *testing.T) {
 		parseTestCase{
 			label: "part with multiple names",
 			given: "violin/viola: c d e",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"violin", "viola"}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.D}},
@@ -43,7 +43,7 @@ func TestParts(t *testing.T) {
 		parseTestCase{
 			label: "part with multiple names and an alias",
 			given: `trumpet/trombone/tuba "brass": c d e`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{
 					Names: []string{"trumpet", "trombone", "tuba"},
 					Alias: "brass",
@@ -56,11 +56,11 @@ func TestParts(t *testing.T) {
 		parseTestCase{
 			label: "multiple parts",
 			given: `guitar: e
-			bass: e`,
-			expect: []model.ScoreUpdate{
+			electric-bass: e`,
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"guitar"}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.E}},
-				model.PartDeclaration{Names: []string{"bass"}},
+				model.PartDeclaration{Names: []string{"electric-bass"}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.E}},
 			},
 		},

--- a/client/parser/repeats_test.go
+++ b/client/parser/repeats_test.go
@@ -31,7 +31,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeat event seq w/ 3 notes",
 			given: "[c d e] *4",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					eventSequence(
 						model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
@@ -45,7 +45,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeat event seq w/ a note and an octave-up",
 			given: "[ c > ]*5",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					eventSequence(
 						model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
@@ -58,7 +58,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeat event seq w/ a note and an octave-up (more whitespace)",
 			given: "[ c > ] * 5",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					eventSequence(
 						model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
@@ -71,7 +71,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeat note w/ explicit duration",
 			given: "c8*7",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					model.Note{
 						Pitch: model.LetterAndAccidentals{NoteLetter: model.C},
@@ -88,7 +88,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeat note w/ explicit duration (more whitespace)",
 			given: "c8 *7",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					model.Note{
 						Pitch: model.LetterAndAccidentals{NoteLetter: model.C},
@@ -105,7 +105,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeat note w/ explicit duration (even more whitespace)",
 			given: "c8 * 7",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					model.Note{
 						Pitch: model.LetterAndAccidentals{NoteLetter: model.C},
@@ -122,7 +122,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeated event sequence containing repeated note",
 			given: "[c*2]*2",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					eventSequence(
 						repeat(
@@ -139,7 +139,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeat w/ repetitions: [c'1,3]*3",
 			given: "[c'1,3]*3",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					eventSequence(
 						eventOnRepetitions(
@@ -154,7 +154,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeat w/ repetitions: [c d'1 e'2]*2",
 			given: "[c d'1 e'2]*2",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					eventSequence(
 						model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
@@ -178,7 +178,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeat w/ repetitions: [c'1-2,4 [d e]'2-3]*4",
 			given: "[c'1-2,4 [d e]'2-3]*4",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					eventSequence(
 						eventOnRepetitions(
@@ -206,7 +206,7 @@ func TestRepeats(t *testing.T) {
 		parseTestCase{
 			label: "repeat w/ repetitions: [{c d e}2'1,3 [f r8 > g]'2-4]*4",
 			given: "[{c d e}2'1,3 [f r8 > g]'2-4]*4",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				repeat(
 					eventSequence(
 						eventOnRepetitions(

--- a/client/parser/test_helper.go
+++ b/client/parser/test_helper.go
@@ -1,50 +1,84 @@
 package parser
 
 import (
+	"math"
 	"testing"
 
 	"alda.io/client/model"
 	"github.com/go-test/deep"
 )
 
-// A parseTestCase models the score updates that should result from parsing a
-// string of Alda code.
+// parseTestCase models a test of the `parser` module
+// parseTestCase also tests Score Updating which tests the `model` module
+// TODO: combine parser + model testing into a single downstream e2e test module
 type parseTestCase struct {
-	label  string
-	given  string
-	expect []model.ScoreUpdate
+	label            string
+	given            string
+	expectUpdates    []model.ScoreUpdate // optional
+	expectAST        *ASTNode            // optional
+	scoreApplyOptOut bool                // optional
 }
 
 // executeParseTestCases parses each test case's given string of Alda code and
-// compares the result with the expected sequence of score updates.
+// tests the parser, scanner, ASTNode.Updates, GenerateASTFromScoreUpdates, and
+// Score Updating (with the ability to opt out)
 func executeParseTestCases(t *testing.T, testCases ...parseTestCase) {
 	for _, testCase := range testCases {
-		// We're suppressing the source context here because we're about to do a
-		// deep diff of our expected list of score updates (which are all devoid of
-		// source context) and the actual list of score updates that result from
-		// parsing the score, and we need them to be considered the same even if the
-		// source context differs.
-		//
-		// By default, the actual list of updates will include source context, which
-		// would cause an avalanche of spurious test failures because the diff would
-		// show numerous differences in the source contexts.
-		actualAST, err :=
-			Parse(testCase.label, testCase.given, SuppressSourceContext)
+		deep.MaxDepth = math.MaxInt32
+
+		// Test parser
+		actualAST, err := Parse(
+			// We suppress source context to facilitate deep diff comparison
+			testCase.label, testCase.given, SuppressSourceContext)
 		if err != nil {
 			t.Errorf("%v\n", err)
 			return
 		}
+		if testCase.expectAST != nil {
+			diff := deep.Equal(testCase.expectAST, actualAST)
+			if diff != nil {
+				t.Error(testCase.label)
+				for _, diffItem := range diff {
+					t.Errorf("%v", diffItem)
+				}
+			}
+		}
 
+		// Test ASTNode -> ScoreUpdate
 		actualUpdates, err := actualAST.Updates()
 		if err != nil {
 			t.Errorf("%v\n", err)
 			return
 		}
+		if testCase.expectUpdates != nil {
+			diff := deep.Equal(testCase.expectUpdates, actualUpdates)
+			if diff != nil {
+				t.Error(testCase.label)
+				for _, diffItem := range diff {
+					t.Errorf("%v", diffItem)
+				}
+			}
+		}
 
-		if diff := deep.Equal(testCase.expect, actualUpdates); diff != nil {
+		// Test code generation by ensuring round-trip generated AST is the same
+		generatedAST, err := GenerateASTFromScoreUpdates(actualUpdates)
+		if err != nil {
+			t.Errorf("%v\n", err)
+			return
+		}
+		if diff := deep.Equal(actualAST, generatedAST); diff != nil {
 			t.Error(testCase.label)
 			for _, diffItem := range diff {
 				t.Errorf("%v", diffItem)
+			}
+		}
+
+		if !testCase.scoreApplyOptOut {
+			score := model.NewScore()
+			err = score.Update(actualUpdates...)
+			if err != nil {
+				t.Errorf(testCase.label)
+				t.Errorf(err.Error())
 			}
 		}
 	}

--- a/client/parser/variables_test.go
+++ b/client/parser/variables_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"testing"
 
 	"alda.io/client/model"
@@ -16,53 +17,37 @@ func variableReference(name string) model.VariableReference {
 	return model.VariableReference{VariableName: name}
 }
 
+func variableNameCheck(name string) parseTestCase {
+	return parseTestCase{
+		label: fmt.Sprintf("variable definition and reference: %s", name),
+		given: fmt.Sprintf("%[1]s = r \n%[1]s", name),
+		expectUpdates: []model.ScoreUpdate{
+			variableDefinition(name, model.Rest{}),
+			variableReference(name),
+		},
+	}
+}
+
 func TestVariables(t *testing.T) {
 	executeParseTestCases(
 		t,
-		parseTestCase{
-			label:  "variable reference: aa",
-			given:  "aa",
-			expect: []model.ScoreUpdate{variableReference("aa")},
-		},
-		parseTestCase{
-			label:  "variable reference: aaa",
-			given:  "aaa",
-			expect: []model.ScoreUpdate{variableReference("aaa")},
-		},
-		parseTestCase{
-			label:  "variable reference: HI",
-			given:  "HI",
-			expect: []model.ScoreUpdate{variableReference("HI")},
-		},
-		parseTestCase{
-			label:  "variable reference: celloPart2",
-			given:  "celloPart2",
-			expect: []model.ScoreUpdate{variableReference("celloPart2")},
-		},
-		parseTestCase{
-			label:  "variable reference: xy42",
-			given:  "xy42",
-			expect: []model.ScoreUpdate{variableReference("xy42")},
-		},
-		parseTestCase{
-			label:  "variable reference: my20cats",
-			given:  "my20cats",
-			expect: []model.ScoreUpdate{variableReference("my20cats")},
-		},
-		parseTestCase{
-			label:  "variable reference: apple_cider",
-			given:  "apple_cider",
-			expect: []model.ScoreUpdate{variableReference("apple_cider")},
-		},
-		parseTestCase{
-			label:  "variable reference: underscores_are_great",
-			given:  "underscores_are_great",
-			expect: []model.ScoreUpdate{variableReference("underscores_are_great")},
-		},
+		variableNameCheck("aa"),
+		variableNameCheck("aaa"),
+		variableNameCheck("HI"),
+		variableNameCheck("celloPart2"),
+		variableNameCheck("xy42"),
+		variableNameCheck("my20cats"),
+		variableNameCheck("apple_cider"),
+		variableNameCheck("underscores_are_great"),
 		parseTestCase{
 			label: "variable reference in a part",
-			given: "flute: c flan f",
-			expect: []model.ScoreUpdate{
+			given: "flan = e\nflute: c flan f",
+			expectUpdates: []model.ScoreUpdate{
+				variableDefinition("flan",
+					model.Note{
+						Pitch: model.LetterAndAccidentals{NoteLetter: model.E},
+					},
+				),
 				model.PartDeclaration{Names: []string{"flute"}},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},
 				variableReference("flan"),
@@ -71,8 +56,9 @@ func TestVariables(t *testing.T) {
 		},
 		parseTestCase{
 			label: "only a variable reference in a part",
-			given: "clarinet: pudding123",
-			expect: []model.ScoreUpdate{
+			given: "pudding123 = r\nclarinet: pudding123",
+			expectUpdates: []model.ScoreUpdate{
+				variableDefinition("pudding123", model.Rest{}),
 				model.PartDeclaration{Names: []string{"clarinet"}},
 				variableReference("pudding123"),
 			},
@@ -80,7 +66,7 @@ func TestVariables(t *testing.T) {
 		parseTestCase{
 			label: "variable definition containing a cram expression",
 			given: "cheesecake = { c/e }2",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				variableDefinition(
 					"cheesecake",
 					model.Cram{
@@ -109,7 +95,7 @@ func TestVariables(t *testing.T) {
 			label: "variable definition within an instrument part",
 			given: `harpsichord:
 			custard_ = c d e/g`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"harpsichord"}},
 				variableDefinition(
 					"custard_",
@@ -131,10 +117,10 @@ func TestVariables(t *testing.T) {
 		parseTestCase{
 			label: "variable definition within an instrument part (variation)",
 			given: `glockenspiel:
-
+		
 			sorbet=c d e/g
 			c`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"glockenspiel"}},
 				variableDefinition(
 					"sorbet",
@@ -157,9 +143,9 @@ func TestVariables(t *testing.T) {
 		parseTestCase{
 			label: "variable definition before an instrument part",
 			given: `GELATO=d e
-
+		
 			clavinet: c/f`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				variableDefinition(
 					"GELATO",
 					model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.D}},
@@ -180,7 +166,7 @@ func TestVariables(t *testing.T) {
 		parseTestCase{
 			label: "var defined and used s/t var ends with a rest",
 			given: "foo = c8 d c r\npiano: foo*2",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				variableDefinition(
 					"foo",
 					model.Note{
@@ -203,8 +189,18 @@ func TestVariables(t *testing.T) {
 		// NB: the trailing newline was essential to reproducing the issue!
 		parseTestCase{
 			label: "variable definition ending with a variable reference",
-			given: "satb = V1: soprano V2: alto V3: tenor V4: bass\n",
-			expect: []model.ScoreUpdate{
+			given: `
+			soprano = r
+			alto = r
+			tenor = r
+			bass = r
+			satb = V1: soprano V2: alto V3: tenor V4: bass
+			`,
+			expectUpdates: []model.ScoreUpdate{
+				variableDefinition("soprano", model.Rest{}),
+				variableDefinition("alto", model.Rest{}),
+				variableDefinition("tenor", model.Rest{}),
+				variableDefinition("bass", model.Rest{}),
 				variableDefinition(
 					"satb",
 					model.VoiceMarker{VoiceNumber: 1},
@@ -222,8 +218,11 @@ func TestVariables(t *testing.T) {
 		// NB: the trailing newline was essential to reproducing the issue!
 		parseTestCase{
 			label: "variable definition followed by a newline",
-			given: "foo = bar\n",
-			expect: []model.ScoreUpdate{
+			given: `bar = r
+			foo = bar
+			`,
+			expectUpdates: []model.ScoreUpdate{
+				variableDefinition("bar", model.Rest{}),
 				variableDefinition("foo", variableReference("bar")),
 			},
 		},

--- a/client/parser/voices_test.go
+++ b/client/parser/voices_test.go
@@ -13,7 +13,7 @@ func TestVoices(t *testing.T) {
 		parseTestCase{
 			label: "part with voice",
 			given: "piano: V1: a b c",
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"piano"}},
 				model.VoiceMarker{VoiceNumber: 1},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.A}},
@@ -26,7 +26,7 @@ func TestVoices(t *testing.T) {
 			given: `piano:
 			V1: a b c
 			V2: d e f`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"piano"}},
 				model.VoiceMarker{VoiceNumber: 1},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.A}},
@@ -42,7 +42,7 @@ func TestVoices(t *testing.T) {
 			label: "part with two voices separated by a barline",
 			given: `piano:
 			V1: a b c | V2: d e f`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"piano"}},
 				model.VoiceMarker{VoiceNumber: 1},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.A}},
@@ -60,7 +60,7 @@ func TestVoices(t *testing.T) {
 			given: `piano:
 			V1: [a b c] *8
 			V2: [d e f] *8`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"piano"}},
 				model.VoiceMarker{VoiceNumber: 1},
 				repeat(
@@ -88,7 +88,7 @@ func TestVoices(t *testing.T) {
 			V1: c
 			V2: e
 			V0: g`,
-			expect: []model.ScoreUpdate{
+			expectUpdates: []model.ScoreUpdate{
 				model.PartDeclaration{Names: []string{"piano"}},
 				model.VoiceMarker{VoiceNumber: 1},
 				model.Note{Pitch: model.LetterAndAccidentals{NoteLetter: model.C}},


### PR DESCRIPTION
# Background
Currently for MusicXML import, we are able to go from MusicXML to Alda `[]ScoreUpdate`. The following 3 PRs combined will introduce an Alda code generator to complete the import process:
1. https://github.com/alda-lang/alda/pull/471
2. https://github.com/alda-lang/alda/pull/474
3. https://github.com/alda-lang/alda/pull/475

This PR is the first step of the process, introducing `[]ScoreUpdate` -> `ASTNode` conversion via the following function in `parser/gen.go`:
```
func GenerateASTFromScoreUpdates(updates []model.ScoreUpdate) (ASTNode, error)
```

# Notes
### `gen.go`
The generation is mostly straightforward, with a few points to note:
1. As commented, `AldaSourceContext` is ignored in generation. I think this is a very fine choice.
2. Processing parts and voices is a little non-trivial. I tried to do it in the cleanest way, but essentially the generator must "reconstruct" an `ASTNode` because `ASTNode.Updates` "flattens" this information in `ScoreUpdate`s.

### `PartUpdate` to `LispListNode`
We only handle conversion for `PartUpdate`'s that are introduced by the MusicXML importer.
We also add `KeySignature.String()` so that we can generate the correct literal for the corresponding `LispStringNode` of a `KeySignatureSet`.

### `test_helper.go`
I've slightly refactored/generalized `parser`'s tests in `parseTestCase` in `test_helper.go`:
1. Now providing actual `ASTNode` or `[]ScoreUpdate` is optional. These are tested if provided. Otherwise, we just test that everything works and that the generated `ASTNode` is equal the parsed `ASTNode`.
2. We now always test applying `ScoreUpdate`s to a `Score` (with an opt out). I also changed a couple test cases so that they could be applied to a score. Let me know if we want it changed.
5. `examples_test.go` which tests the example files now uses `parseTestCase`.

### `e2e`
We've talked about a complete refactor of testing to spin-off an `e2e` testing module downstream of both `parser` and `model`. I think the changes we have now are "good enough" that this change is not quite worth it for now, given my timeline. I've left it as a TODO.

