### PR TITLE
Alda Code Formatter

### DIFF
--- a/client/cmd/format.go
+++ b/client/cmd/format.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"alda.io/client/color"
+	"alda.io/client/help"
+	log "alda.io/client/logging"
+	"alda.io/client/parser"
+	"fmt"
+	"github.com/spf13/cobra"
+	"io"
+	"os"
+)
+
+var formatInputFile string
+var formatOverwrite bool
+var formatConfiguredWrapLen int
+var formatConfiguredIndentText string
+
+func init() {
+	formatCmd.Flags().StringVarP(
+		&formatInputFile, "file", "f", "", "Input Alda file to format",
+	)
+
+	formatCmd.Flags().BoolVarP(
+		&formatOverwrite, "output", "o", false, "Overwrite input file with formatted output",
+	)
+
+	formatCmd.Flags().IntVarP(
+		&formatConfiguredWrapLen, "wrap", "w", 0, "Configured line character length to wrap formatted output (default 80)",
+	)
+
+	formatCmd.Flags().StringVarP(
+		&formatConfiguredIndentText, "indent", "i", "", "Configured indent text (default two spaces)",
+	)
+}
+
+var formatCmd = &cobra.Command{
+	Use:    "format",
+	Hidden: true,
+	Short:  "Format Alda source code",
+	Long: `Format Alda source code
+
+---
+
+Source code must be provided by specifying the path to a file (-f, --file):
+  alda format -f path/to/my-score.alda
+
+In this case, the formatted output will be printed to standard output.
+
+When -o / --output is specified, the input file is instead overwritten.
+  alda format -f path/to/my-score.alda -o
+
+Formatted output can be configured with the -w / --wrap and -i / --indent flags.
+  alda format -f path/to/my-score.alda -w 120 -i "    "
+
+---
+
+Currently, formatting cannot handle comments (i.e. all comments are dropped)
+
+---`,
+	RunE: func(_ *cobra.Command, args []string) error {
+		// TODO (experimental): remove warning log
+		log.Warn().Msg(fmt.Sprintf(
+			`The %s command is currently experimental. All comments are dropped during formatting.`,
+			color.Aurora.BrightYellow("format"),
+		))
+
+		root, err := parser.ParseFile(formatInputFile)
+		if err != nil {
+			return err
+		}
+
+		var out io.Writer
+		if formatOverwrite {
+			f, err := os.OpenFile(
+				formatInputFile,
+				os.O_WRONLY|os.O_TRUNC,
+				0664, // default rw-rw-r perms
+			)
+			if err != nil {
+				return help.UserFacingErrorf(
+					`Issue opening file %s.`,
+					color.Aurora.BrightYellow(outputAldaFilename),
+				)
+			}
+			defer f.Close()
+			out = f
+		} else {
+			out = os.Stdout
+		}
+
+		if formatConfiguredWrapLen < 0 {
+			return help.UserFacingErrorf(
+				`Configured line wrap length %d must be positive.`,
+				formatConfiguredWrapLen,
+			)
+		}
+
+		if formatConfiguredWrapLen > 0 && len(formatConfiguredIndentText) > 0 {
+			err = parser.FormatASTToCode(
+				root,
+				out,
+				parser.ConfigureSoftWrapLen(formatConfiguredWrapLen),
+				parser.ConfigureIndentText(formatConfiguredIndentText),
+			)
+		} else if formatConfiguredWrapLen > 0 {
+			err = parser.FormatASTToCode(
+				root,
+				out,
+				parser.ConfigureSoftWrapLen(formatConfiguredWrapLen),
+			)
+		} else if len(formatConfiguredIndentText) > 0 {
+			err = parser.FormatASTToCode(
+				root,
+				out,
+				parser.ConfigureIndentText(formatConfiguredIndentText),
+			)
+		} else {
+			err = parser.FormatASTToCode(root, out)
+		}
+
+		if err != nil {
+			return help.UserFacingErrorf(
+				`Issue formatting Alda: %s.`,
+				err.Error(),
+			)
+		}
+
+		return nil
+	},
+}

--- a/client/cmd/format.go
+++ b/client/cmd/format.go
@@ -22,7 +22,7 @@ func init() {
 	)
 
 	formatCmd.Flags().BoolVarP(
-		&formatOverwrite, "output", "o", false, "Overwrite input file with formatted output",
+		&formatOverwrite, "overwrite", "o", false, "Overwrite input file with formatted output",
 	)
 
 	formatCmd.Flags().IntVarP(
@@ -47,7 +47,7 @@ Source code must be provided by specifying the path to a file (-f, --file):
 
 In this case, the formatted output will be printed to standard output.
 
-When -o / --output is specified, the input file is instead overwritten.
+When -o / --overwrite is specified, the input file is instead overwritten.
   alda format -f path/to/my-score.alda -o
 
 Formatted output can be configured with the -w / --wrap and -i / --indent flags.

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -240,6 +240,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	for _, cmd := range []*cobra.Command{
 		doctorCmd,
 		exportCmd,
+		formatCmd,
 		importCmd,
 		instrumentsCmd,
 		parseCmd,

--- a/client/model/duration.go
+++ b/client/model/duration.go
@@ -151,6 +151,36 @@ func (nl NoteLengthMs) Ms(tempo float64) float64 {
 	return nl.Quantity
 }
 
+// NoteLengthSeconds expresses a duration as a specific number of seconds.
+type NoteLengthSeconds struct {
+	Quantity float64
+}
+
+func (nl NoteLengthSeconds) Validate() error {
+	if nl.Quantity <= 0 {
+		return help.UserFacingErrorf(
+			`The number of seconds must be positive.`,
+		)
+	}
+
+	return nil
+}
+
+// JSON implements RepresentableAsJSON.JSON.
+func (nl NoteLengthSeconds) JSON() *json.Container {
+	return json.Object("s", nl.Quantity)
+}
+
+func (nl NoteLengthSeconds) Beats() float64 {
+	panic("A second note length cannot be expressed in beats")
+}
+
+// Ms implements DurationComponent.Ms by describing a specific number of
+// milliseconds.
+func (nl NoteLengthSeconds) Ms(tempo float64) float64 {
+	return nl.Quantity * 1000
+}
+
 // Duration describes the length of time occupied by a note or other event.
 type Duration struct {
 	Components []DurationComponent

--- a/client/parser/ast.go
+++ b/client/parser/ast.go
@@ -36,6 +36,7 @@ const (
 	NoteAccidentalsNode
 	NoteLengthMsNode
 	NoteLengthNode
+	NoteLengthSecondsNode
 	NoteLetterAndAccidentalsNode
 	NoteLetterNode
 	NoteNode
@@ -118,6 +119,8 @@ func (nt ASTNodeType) String() string {
 		return "NoteLengthMsNode"
 	case NoteLengthNode:
 		return "NoteLengthNode"
+	case NoteLengthSecondsNode:
+		return "NoteLengthSecondsNode"
 	case NoteLetterAndAccidentalsNode:
 		return "NoteLetterAndAccidentalsNode"
 	case NoteLetterNode:
@@ -354,6 +357,10 @@ func duration(node ASTNode) (model.Duration, error) {
 			literal := componentNode.Literal.(float64)
 			noteLengthMs := model.NoteLengthMs{Quantity: literal}
 			duration.Components = append(duration.Components, noteLengthMs)
+		case NoteLengthSecondsNode:
+			literal := componentNode.Literal.(float64)
+			noteLengthSeconds := model.NoteLengthSeconds{Quantity: literal}
+			duration.Components = append(duration.Components, noteLengthSeconds)
 		}
 	}
 

--- a/client/parser/ast.go
+++ b/client/parser/ast.go
@@ -278,19 +278,21 @@ func (node ASTNode) expectChildren() error {
 	return nil
 }
 
-func (node ASTNode) expectNChildren(expectedChildren int) error {
+func (node ASTNode) expectNChildren(expectedChildren ...int) error {
 	actualChildren := len(node.Children)
 
-	if actualChildren != expectedChildren {
-		return fmt.Errorf(
-			"expected %s to have %d children, but it has %d",
-			node.Type.String(),
-			expectedChildren,
-			actualChildren,
-		)
+	for _, expected := range expectedChildren {
+		if actualChildren == expected {
+			return nil
+		}
 	}
 
-	return nil
+	return fmt.Errorf(
+		"expected %s to have %v children, but it has %d",
+		node.Type.String(),
+		expectedChildren,
+		actualChildren,
+	)
 }
 
 func (node ASTNode) expectNodeType(expectedType ASTNodeType) (ASTNode, error) {
@@ -407,7 +409,7 @@ func (node ASTNode) Updates() ([]model.ScoreUpdate, error) {
 		}, nil
 
 	case CramNode:
-		if err := node.expectChildren(); err != nil {
+		if err := node.expectNChildren(1, 2); err != nil {
 			return nil, err
 		}
 

--- a/client/parser/duration_test.go
+++ b/client/parser/duration_test.go
@@ -56,7 +56,7 @@ func TestDurations(t *testing.T) {
 			label: "Note with duration in seconds",
 			given: "c2s",
 			expectUpdates: []model.ScoreUpdate{
-				cNoteWithDuration(model.NoteLengthMs{Quantity: 2000}),
+				cNoteWithDuration(model.NoteLengthSeconds{Quantity: 2}),
 			},
 		},
 		parseTestCase{
@@ -96,7 +96,7 @@ func TestDurations(t *testing.T) {
 			given: "c5s~4~350ms~0.5",
 			expectUpdates: []model.ScoreUpdate{
 				cNoteWithDuration(
-					model.NoteLengthMs{Quantity: 5000},
+					model.NoteLengthSeconds{Quantity: 5},
 					model.NoteLength{Denominator: 4},
 					model.NoteLengthMs{Quantity: 350},
 					model.NoteLength{Denominator: 0.5},

--- a/client/parser/event_sequences_test.go
+++ b/client/parser/event_sequences_test.go
@@ -130,7 +130,7 @@ func TestEventSequences(t *testing.T) {
 						Pitch: model.LetterAndAccidentals{NoteLetter: model.C},
 						Duration: model.Duration{
 							Components: []model.DurationComponent{
-								model.NoteLengthMs{Quantity: 1000},
+								model.NoteLengthSeconds{Quantity: 1},
 							},
 						},
 					},

--- a/client/parser/format.go
+++ b/client/parser/format.go
@@ -152,34 +152,6 @@ func (f *formatter) formatWithDuration(
 
 			text.Reset()
 
-		case NoteLengthMsNode:
-			if shouldTie {
-				text.WriteString("~")
-			}
-
-			// NoteLengthMs is parsed to us as ms, but can be coded using s/ms
-			// We will try our best to use seconds first
-			totalMs := child.Literal.(float64)
-			s := int(totalMs) / 1000
-			ms := totalMs - float64(s*1000)
-
-			if s > 0 && ms > 0 {
-				text.WriteString(fmt.Sprintf(
-					"%ds~%sms",
-					s,
-					strconv.FormatFloat(ms, 'f', -1, 64),
-				))
-			} else if s > 0 {
-				text.WriteString(fmt.Sprintf("%ds", s))
-			} else {
-				text.WriteString(fmt.Sprintf(
-					"%sms",
-					strconv.FormatFloat(ms, 'f', -1, 64),
-				))
-			}
-
-			shouldTie = true
-
 		case NoteLengthNode:
 			if shouldTie {
 				text.WriteString("~")
@@ -208,6 +180,30 @@ func (f *formatter) formatWithDuration(
 				"%s%s",
 				strconv.FormatFloat(denom.Literal.(float64), 'f', -1, 64),
 				strings.Repeat(".", numDots),
+			))
+
+			shouldTie = true
+
+		case NoteLengthMsNode:
+			if shouldTie {
+				text.WriteString("~")
+			}
+
+			text.WriteString(fmt.Sprintf(
+				"%sms",
+				strconv.FormatFloat(child.Literal.(float64), 'f', -1, 64),
+			))
+
+			shouldTie = true
+
+		case NoteLengthSecondsNode:
+			if shouldTie {
+				text.WriteString("~")
+			}
+
+			text.WriteString(fmt.Sprintf(
+				"%ss",
+				strconv.FormatFloat(child.Literal.(float64), 'f', -1, 64),
 			))
 
 			shouldTie = true

--- a/client/parser/format.go
+++ b/client/parser/format.go
@@ -1,0 +1,759 @@
+package parser
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+type varDefState int
+
+const (
+	None     = iota // not currently in a var def
+	Defining        // currently formatting a var def (cannot go to new line)
+	LastNode        // last node of a var def, treated specially
+)
+
+type formatter struct {
+	softWrapLen int         // configured line length to soft wrap formatting
+	indentText  string      // configured indent string (i.e. spaces vs tabs)
+	varDef      varDefState // state to handle formatting variable definitions
+	indentLevel int         // state for indentation level
+	texts       []string    // buffer of "tokens" for the ongoing formatted line
+	out         io.Writer
+}
+
+type formatterOption func(*formatter)
+
+func ConfigureSoftWrapLen(len int) func(*formatter) {
+	return func(f *formatter) {
+		f.softWrapLen = len
+	}
+}
+
+func ConfigureIndentText(text string) func(*formatter) {
+	return func(f *formatter) {
+		f.indentText = text
+	}
+}
+
+func newFormatter(out io.Writer, opts ...formatterOption) *formatter {
+	formatter := &formatter{
+		softWrapLen: 80,
+		indentText:  "  ",
+		varDef:      None,
+		indentLevel: 0,
+		texts:       []string{},
+		out:         out,
+	}
+
+	for _, opt := range opts {
+		opt(formatter)
+	}
+
+	return formatter
+}
+
+// line constructs and returns the current line being formatted.
+func (f *formatter) line() string {
+	text := strings.Join(f.texts, " ")
+	if len(text) == 0 {
+		return text
+	} else {
+		indent := strings.Repeat(f.indentText, f.indentLevel)
+		return indent + text
+	}
+}
+
+// emptyLine writes an empty line
+func (f *formatter) emptyLine() {
+	if f.varDef == None {
+		f.flush()
+		f.out.Write([]byte("\n"))
+	}
+}
+
+// flush flushes out the current line to the output.
+func (f *formatter) flush() {
+	if len(f.texts) > 0 && f.varDef == None {
+		f.out.Write([]byte(f.line() + "\n"))
+		f.texts = []string{}
+	}
+}
+
+// indent increments the indentation level of subsequent formatting.
+func (f *formatter) indent() {
+	switch f.varDef {
+	case LastNode:
+		// During the last node of a var def, we are allowed to effectively exit
+		// the var def and continue formatting on the next line.
+		f.varDef = None
+		fallthrough
+	case None:
+		f.flush()
+		f.indentLevel++
+	}
+}
+
+// unindent decrements the indentation level of subsequent formatting.
+// A corresponding unindent should always be called after calling indent.
+func (f *formatter) unindent() {
+	if f.varDef == None {
+		f.flush()
+		f.indentLevel--
+	}
+}
+
+// write formats text to the output with indentation, wrapping, and spacing.
+// Each "text" is an unwrappable token, i.e. wrapping only happens between text.
+func (f *formatter) write(text string) {
+	f.texts = append(f.texts, text)
+	if len(f.line()) > f.softWrapLen && f.varDef == None {
+		f.texts = f.texts[0 : len(f.texts)-1]
+		f.flush()
+		f.texts = append(f.texts, text)
+	}
+}
+
+// formatWithDuration handles duration formatting.
+// Durations are formatted with possible text directly pre/post (no spaces),
+// i.e. note pitches preceding durations.
+// All durations are treated as a single unwrappable text with the exception of
+// barlines which cause a duration to be split into separate texts.
+func (f *formatter) formatWithDuration(
+	pre string, duration ASTNode, post string,
+) error {
+	text := strings.Builder{}
+	text.WriteString(pre)
+	shouldTie := false
+
+	for i, child := range duration.Children {
+		switch child.Type {
+
+		default:
+			return fmt.Errorf(
+				"unexpected DurationNode %#v during formatting", child,
+			)
+
+		case BarlineNode:
+			if i == len(duration.Children)-1 {
+				// The final duration is a barline
+				// We write out any post text before the barline for clarity
+				text.WriteString(post)
+			}
+
+			// Barlines in a duration split formatting into separate texts
+			if text.Len() > 0 {
+				f.write(text.String())
+			}
+			f.write("|")
+
+			text.Reset()
+
+		case NoteLengthMsNode:
+			if shouldTie {
+				text.WriteString("~")
+			}
+
+			// NoteLengthMs is parsed to us as ms, but can be coded using s/ms
+			// We will try our best to use seconds first
+			totalMs := child.Literal.(float64)
+			s := int(totalMs) / 1000
+			ms := totalMs - float64(s*1000)
+
+			if s > 0 && ms > 0 {
+				text.WriteString(fmt.Sprintf(
+					"%ds~%sms",
+					s,
+					strconv.FormatFloat(ms, 'f', -1, 64),
+				))
+			} else if s > 0 {
+				text.WriteString(fmt.Sprintf("%ds", s))
+			} else {
+				text.WriteString(fmt.Sprintf(
+					"%sms",
+					strconv.FormatFloat(ms, 'f', -1, 64),
+				))
+			}
+
+			shouldTie = true
+
+		case NoteLengthNode:
+			if shouldTie {
+				text.WriteString("~")
+			}
+
+			if err := child.expectNChildren(1, 2); err != nil {
+				return err
+			}
+
+			denom, err := child.Children[0].expectNodeType(DenominatorNode)
+			if err != nil {
+				return err
+			}
+
+			numDots := 0
+			if len(child.Children) > 1 {
+				dotsNode, err := child.Children[1].expectNodeType(DotsNode)
+				if err != nil {
+					return err
+				}
+
+				numDots = int(dotsNode.Literal.(int32))
+			}
+
+			text.WriteString(fmt.Sprintf(
+				"%s%s",
+				strconv.FormatFloat(denom.Literal.(float64), 'f', -1, 64),
+				strings.Repeat(".", numDots),
+			))
+
+			shouldTie = true
+
+		}
+	}
+
+	if text.Len() > 0 {
+		text.WriteString(post)
+		f.write(text.String())
+	}
+
+	return nil
+}
+
+// formatInnerEvents handles formatting of inner events within parts.
+func (f *formatter) formatInnerEvents(nodes ...ASTNode) error {
+	for _, node := range nodes {
+		switch node.Type {
+
+		default:
+			return fmt.Errorf(
+				"unexpected ASTNode Type %#v during formatting", node.Type,
+			)
+
+		case AtMarkerNode:
+			f.write(fmt.Sprintf("@%s", node.Literal.(string)))
+
+		case BarlineNode:
+			f.write("|")
+
+		case ChordNode:
+			// We make each note + each separator individual texts to format
+			// Meaning extra spaces padding separators + chords can be wrapped
+			// This is to avoid additional complexity in the formatter
+			// We can change this by creating a new helper function for
+			// inner-chord nodes that returns a []string of texts
+			// Would have to handle the fact that barlines make multiple writes
+
+			if err := node.expectChildren(); err != nil {
+				return err
+			}
+
+			// Within a chord, there can be additional nodes between notes
+			// We format all of these after the separator for readability as
+			// they apply to the subsequent note
+			lastNoteOrRest := 0
+			for i, child := range node.Children {
+				if child.Type == NoteNode || child.Type == RestNode {
+					lastNoteOrRest = i
+				}
+			}
+
+			for i, child := range node.Children {
+				err := f.formatInnerEvents(child)
+				if err != nil {
+					return err
+				}
+
+				if child.Type == NoteNode || child.Type == RestNode {
+					if i < lastNoteOrRest {
+						f.write("/")
+					}
+				}
+			}
+
+		case CramNode:
+			if err := node.expectNChildren(1, 2); err != nil {
+				return err
+			}
+
+			events, err := node.Children[0].expectNodeType(EventSequenceNode)
+			if err != nil {
+				return err
+			}
+
+			f.write("{")
+
+			err = f.formatInnerEvents(events.Children...)
+			if err != nil {
+				return err
+			}
+
+			if len(node.Children) > 1 {
+				duration, err := node.Children[1].expectNodeType(DurationNode)
+				if err != nil {
+					return err
+				}
+
+				err = f.formatWithDuration("}", duration, "")
+				if err != nil {
+					return err
+				}
+			} else {
+				f.write("}")
+			}
+
+		case EventSequenceNode:
+			// Always try to indent the children of standalone event sequences
+			// (i.e. those not used as part of a separate node such as cram)
+			f.flush()
+			f.write("[")
+			f.indent()
+
+			err := f.formatInnerEvents(node.Children...)
+			if err != nil {
+				return err
+			}
+
+			f.unindent()
+			f.write("]")
+
+		case LispListNode:
+			var lispString func(ASTNode) (string, error)
+			lispString = func(lisp ASTNode) (string, error) {
+				switch lisp.Type {
+
+				default:
+					return "", fmt.Errorf(
+						"unexpected LispListNode %#v during formatting", lisp,
+					)
+
+				case LispListNode:
+					texts := []string{}
+
+					for _, child := range lisp.Children {
+						text, err := lispString(child)
+						if err != nil {
+							return "", err
+						}
+
+						texts = append(texts, text)
+					}
+
+					return fmt.Sprintf("(%s)", strings.Join(texts, " ")), nil
+
+				case LispNumberNode:
+					switch num := lisp.Literal.(type) {
+					default:
+						return "", fmt.Errorf(
+							"unexpected LispNumberNode %#v during formatting",
+							num,
+						)
+					case float64:
+						return strconv.FormatFloat(
+							num, 'f', -1, 64,
+						), nil
+					case int32:
+						return fmt.Sprintf("%d", num), nil
+					}
+
+				case LispQuotedFormNode:
+					form, err := lispString(lisp.Children[0])
+					if err != nil {
+						return "", err
+					}
+
+					return fmt.Sprintf("'%s", form), nil
+
+				case LispStringNode:
+					return fmt.Sprintf("\"%s\"", lisp.Literal.(string)), nil
+
+				case LispSymbolNode:
+					return lisp.Literal.(string), nil
+
+				}
+			}
+
+			text, err := lispString(node)
+			if err != nil {
+				return err
+			}
+
+			// Lisp lists are generally short
+			// We write them as a single unwrappable text for readability
+			f.write(text)
+
+		case MarkerNode:
+			f.write(fmt.Sprintf("%%%s", node.Literal.(string)))
+
+		case NoteNode:
+			if err := node.expectNChildren(1, 2, 3); err != nil {
+				return err
+			}
+
+			laa, err := node.Children[0].expectNodeType(
+				NoteLetterAndAccidentalsNode,
+			)
+			if err != nil {
+				return err
+			}
+
+			if err := laa.expectChildren(); err != nil {
+				return err
+			}
+
+			letter, err := laa.Children[0].expectNodeType(NoteLetterNode)
+			if err != nil {
+				return err
+			}
+
+			pitchText := strings.Builder{}
+			pitchText.WriteRune(letter.Literal.(rune))
+
+			if len(laa.Children) > 1 {
+				accidentals, err := laa.Children[1].expectNodeType(
+					NoteAccidentalsNode,
+				)
+				if err != nil {
+					return err
+				}
+
+				for _, child := range accidentals.Children {
+					switch child.Type {
+					default:
+						return fmt.Errorf(
+							"unexpected NoteAccidentalsNode %#v during formatting",
+							child,
+						)
+					case FlatNode:
+						pitchText.WriteString("-")
+					case NaturalNode:
+						pitchText.WriteString("_")
+					case SharpNode:
+						pitchText.WriteString("+")
+					}
+				}
+			}
+
+			slurText := ""
+			for _, child := range node.Children[1:] {
+				if child.Type == TieNode {
+					slurText = "~"
+				}
+			}
+
+			if len(node.Children) > 1 && node.Children[1].Type == DurationNode {
+				err = f.formatWithDuration(
+					pitchText.String(), node.Children[1], slurText,
+				)
+				if err != nil {
+					return err
+				}
+			} else {
+				f.write(fmt.Sprintf("%s%s", pitchText.String(), slurText))
+			}
+
+		case OctaveDownNode:
+			f.write("<")
+
+		case OctaveSetNode:
+			f.write(fmt.Sprintf("o%d", node.Literal.(int32)))
+
+		case OctaveUpNode:
+			f.write(">")
+
+		case RepeatNode:
+			if err := node.expectNChildren(2); err != nil {
+				return err
+			}
+
+			err := f.formatInnerEvents(node.Children[0])
+			if err != nil {
+				return err
+			}
+
+			times, err := node.Children[1].expectNodeType(TimesNode)
+			if err != nil {
+				return err
+			}
+
+			f.write(fmt.Sprintf("*%d", times.Literal.(int32)))
+
+		case OnRepetitionsNode:
+			if err := node.expectNChildren(2); err != nil {
+				return err
+			}
+
+			err := f.formatInnerEvents(node.Children[0])
+			if err != nil {
+				return err
+			}
+
+			repetitions, err := node.Children[1].expectNodeType(RepetitionsNode)
+			if err != nil {
+				return err
+			}
+
+			ranges := []string{}
+			for _, child := range repetitions.Children {
+				rr, err := child.expectNodeType(RepetitionRangeNode)
+				if err != nil {
+					return err
+				}
+
+				if err := rr.expectNChildren(2); err != nil {
+					return err
+				}
+
+				fr, err := rr.Children[0].expectNodeType(FirstRepetitionNode)
+				if err != nil {
+					return err
+				}
+
+				lr, err := rr.Children[1].expectNodeType(LastRepetitionNode)
+				if err != nil {
+					return err
+				}
+
+				frNum := fr.Literal.(int32)
+				lrNum := lr.Literal.(int32)
+
+				if frNum == lrNum {
+					ranges = append(ranges,
+						fmt.Sprintf("%d", frNum),
+					)
+				} else {
+					ranges = append(ranges,
+						fmt.Sprintf("%d-%d", frNum, lrNum),
+					)
+				}
+			}
+			f.write(fmt.Sprintf("'%s", strings.Join(ranges, ",")))
+
+		case RestNode:
+			if len(node.Children) > 0 {
+				duration, err := node.Children[0].expectNodeType(DurationNode)
+				if err != nil {
+					return err
+				}
+
+				err = f.formatWithDuration("r", duration, "")
+				if err != nil {
+					return err
+				}
+			} else {
+				f.write("r")
+			}
+
+		case VariableDefinitionNode:
+			// Variable definitions are incredibly tricky to format because
+			// formatted text must be on the same line as the variable name.
+			// We handle this by maintaining varDefState:
+			// - While "None", behaviour is normal.
+			// - While "Defining", we never flush/wrap to a new line.
+			// - While "LastNode", we allow event sequences (including repeats)
+			// 	 and voice groups to indent and continue on new lines.
+			// 	 This is complicated, but any alternative I tried was worse.
+
+			f.flush()
+			f.varDef = Defining
+
+			if err := node.expectNChildren(2); err != nil {
+				return err
+			}
+
+			name, err := node.Children[0].expectNodeType(VariableNameNode)
+			if err != nil {
+				return err
+			}
+
+			f.write(fmt.Sprintf("%s =", name.Literal.(string)))
+
+			events, err := node.Children[1].expectNodeType(EventSequenceNode)
+			if err != nil {
+				return err
+			}
+
+			if len(events.Children) > 0 {
+				lastIndex := len(events.Children) - 1
+
+				err = f.formatInnerEvents(events.Children[:lastIndex]...)
+				if err != nil {
+					return err
+				}
+
+				f.varDef = LastNode
+
+				err = f.formatInnerEvents(events.Children[lastIndex])
+				if err != nil {
+					return err
+				}
+			}
+
+			f.varDef = None
+			f.flush()
+
+		case VariableReferenceNode:
+			f.write(node.Literal.(string))
+
+		case VoiceGroupEndMarkerNode:
+			f.write("V0:")
+
+		case VoiceGroupNode:
+			f.flush()
+			err := f.formatInnerEvents(node.Children...)
+			if err != nil {
+				return err
+			}
+
+		case VoiceNode:
+			if err := node.expectNChildren(2); err != nil {
+				return err
+			}
+
+			voiceNumber, err := node.Children[0].expectNodeType(VoiceNumberNode)
+			if err != nil {
+				return err
+			}
+
+			f.write(fmt.Sprintf("V%d:", voiceNumber.Literal.(int32)))
+
+			f.indent()
+
+			events, err := node.Children[1].expectNodeType(EventSequenceNode)
+			if err != nil {
+				return err
+			}
+
+			err = f.formatInnerEvents(events.Children...)
+			if err != nil {
+				return err
+			}
+
+			f.unindent()
+
+		}
+	}
+
+	return nil
+}
+
+// formatTopLevel handles formatting for the RootNode and parts.
+func (f *formatter) formatTopLevel(root ASTNode) error {
+	for i, part := range root.Children {
+		switch part.Type {
+
+		case ImplicitPartNode:
+			if err := part.expectNChildren(1); err != nil {
+				return err
+			}
+
+			events, err := part.Children[0].expectNodeType(EventSequenceNode)
+			if err != nil {
+				return err
+			}
+
+			err = f.formatInnerEvents(events.Children...)
+			if err != nil {
+				return err
+			}
+
+		case PartNode:
+			if err := part.expectNChildren(2); err != nil {
+				return err
+			}
+
+			// Part declaration
+			decl, err := part.Children[0].expectNodeType(PartDeclarationNode)
+			if err != nil {
+				return err
+			}
+
+			if err := decl.expectNChildren(1, 2); err != nil {
+				return err
+			}
+
+			partNames, err := decl.Children[0].expectNodeType(PartNamesNode)
+			if err != nil {
+				return err
+			}
+
+			if err := partNames.expectChildren(); err != nil {
+				return err
+			}
+
+			names := []string{}
+			for _, child := range partNames.Children {
+				partNameNode, err := child.expectNodeType(PartNameNode)
+				if err != nil {
+					return err
+				}
+
+				names = append(names, partNameNode.Literal.(string))
+			}
+			namesText := strings.Join(names, "/")
+
+			if len(decl.Children) > 1 {
+				partAlias, err := decl.Children[1].expectNodeType(
+					PartAliasNode,
+				)
+				if err != nil {
+					return err
+				}
+
+				f.write(fmt.Sprintf(
+					"%s \"%s\":",
+					namesText,
+					partAlias.Literal.(string),
+				))
+			} else {
+				f.write(fmt.Sprintf(
+					"%s:",
+					namesText,
+				))
+			}
+
+			// Part events
+			f.indent()
+
+			events, err := part.Children[1].expectNodeType(EventSequenceNode)
+			if err != nil {
+				return err
+			}
+
+			err = f.formatInnerEvents(events.Children...)
+			if err != nil {
+				return err
+			}
+
+			f.unindent()
+
+		}
+
+		f.flush()
+		if i+1 < len(root.Children) {
+			f.emptyLine()
+		}
+	}
+
+	return nil
+}
+
+// FormatASTToCode performs rudimentary output formatting of Alda code including
+// handling basic spacing, indentation, and line wrapping.
+// TODO: handle formatting comments by retaining comment data to the AST layer.
+func FormatASTToCode(
+	root ASTNode, out io.Writer, opts ...formatterOption,
+) error {
+	// Write to temp buffer instead of directly to file in case of error
+	temp := bytes.Buffer{}
+	f := newFormatter(&temp, opts...)
+	err := f.formatTopLevel(root)
+	if err != nil {
+		return err
+	}
+	_, err = out.Write(temp.Bytes())
+	return err
+}

--- a/client/parser/gen.go
+++ b/client/parser/gen.go
@@ -41,6 +41,12 @@ func withDuration(node ASTNode, duration model.Duration) (ASTNode, error) {
 				Literal: c.Quantity,
 			})
 
+		case model.NoteLengthSeconds:
+			durationNode.Children = append(durationNode.Children, ASTNode{
+				Type:    NoteLengthSecondsNode,
+				Literal: c.Quantity,
+			})
+
 		default:
 			// model.NoteLengthBeats - only generated within lisp
 			return ASTNode{}, fmt.Errorf(

--- a/client/parser/parser.go
+++ b/client/parser/parser.go
@@ -444,7 +444,7 @@ func (p *parser) octaveSet() (ASTNode, error) {
 }
 
 func (p *parser) matchDurationComponent() (Token, bool) {
-	return p.match(NoteLength, NoteLengthMs)
+	return p.match(NoteLength, NoteLengthMs, NoteLengthSeconds)
 }
 
 func (p *parser) durationComponent() ASTNode {
@@ -477,6 +477,12 @@ func (p *parser) durationComponent() ASTNode {
 	case NoteLengthMs:
 		return ASTNode{
 			Type:          NoteLengthMsNode,
+			SourceContext: p.sourceContext(token),
+			Literal:       token.literal,
+		}
+	case NoteLengthSeconds:
+		return ASTNode{
+			Type:          NoteLengthSecondsNode,
 			SourceContext: p.sourceContext(token),
 			Literal:       token.literal,
 		}

--- a/client/parser/scanner.go
+++ b/client/parser/scanner.go
@@ -77,6 +77,7 @@ const (
 	Natural
 	NoteLength
 	NoteLengthMs
+	NoteLengthSeconds
 	NoteLetter
 	Number
 	OctaveDown
@@ -141,6 +142,8 @@ func (tt TokenType) String() string {
 		return "note length"
 	case NoteLengthMs:
 		return "note length (ms)"
+	case NoteLengthSeconds:
+		return "note length (s)"
 	case NoteLetter:
 		return "note letter"
 	case Number:
@@ -377,7 +380,7 @@ func (s *scanner) parseNoteLength() {
 	if c == 's' && (terminatesNoteLength(n) || s.eofIsNext()) {
 		// consume 's'
 		s.advance()
-		s.addToken(NoteLengthMs, number*1000)
+		s.addToken(NoteLengthSeconds, number)
 		return
 	}
 

--- a/client/parser/test_helper.go
+++ b/client/parser/test_helper.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"math"
 	"testing"
 
@@ -67,6 +68,23 @@ func executeParseTestCases(t *testing.T, testCases ...parseTestCase) {
 			return
 		}
 		if diff := deep.Equal(actualAST, generatedAST); diff != nil {
+			t.Error(testCase.label)
+			for _, diffItem := range diff {
+				t.Errorf("%v", diffItem)
+			}
+		}
+
+		// Test formatter by ensuring round-trip formatted + parsed AST is same
+		buffer := bytes.Buffer{}
+		err = FormatASTToCode(actualAST, &buffer)
+		if err != nil {
+			t.Errorf("%v\n", err)
+			return
+		}
+		formattedAST, err := Parse(
+			// The newly formatted file will have different source context's
+			testCase.label, buffer.String(), SuppressSourceContext)
+		if diff := deep.Equal(actualAST, formattedAST); diff != nil {
 			t.Error(testCase.label)
 			for _, diffItem := range diff {
 				t.Errorf("%v", diffItem)


### PR DESCRIPTION
# Background
Currently for MusicXML import, we are able to go from MusicXML to Alda `[]ScoreUpdate`. The following 3 PRs combined will introduce an Alda code generator to complete the import process:
1. https://github.com/alda-lang/alda/pull/471
2. https://github.com/alda-lang/alda/pull/474
3. https://github.com/alda-lang/alda/pull/475

This PR introduces a code formatter, translating `ASTNode` to Alda code.
```
func FormatASTToCode(root ASTNode, out io.Writer, opts ...formatterOption) error {
```

# Notes
### Whitespaces
The formatter is quite rudimentary, but has basic handling of whitespacing (indents, spaces, line wrapping) while maintaining the integrity of the generated code.
- For indents, we essentially maintain an indentation level. Within parts, voices, and event seqs, we indent.
- For wrapping, we format "texts" or tokens that are single strings. Between texts, we can wrap the line.

### Variable Definitions
Variable definitions are tricky as I've noted in code comments. As a summary, the problem is all definition nodes must be on the same line as the variable name. The easiest way I found to handle this is to introduce the `varDefState` enum, which introduces some significant complexity into the formatter.

### Testing
We piggyback and use the `parseTestCase` to also automatically test formatting. Like with ast-gen, we ensure the "round-trip" formatted then parsed AST is identical to the actual correct AST.

### Comments
Currently comments are dropped when scanning, so they will be dropped for a round-trip format (code -> AST -> code).

I've spent a couple hours trying my hand at the changes necessary to retain comments to the AST level. I think this change is not worth it, as it's quite complicated and touches sensitive code. Plus MusicXML import doesn't produce comments, so the change is not necessary for this main use case. Plus the formatter itself is not very good, so I don't think it'll really standalone.

I've left supporting comments as a TODO.

### Commands
The formatter is not quite good enough in my opinion to standalone as it's own command to actually use. Combined with the fact that we don't even support comments, we will introduce an experimental hidden `alda format` command.
