### PR TITLE
refactor: remove io/ioutil

### DIFF
--- a/client/cmd/doctor.go
+++ b/client/cmd/doctor.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -372,7 +371,7 @@ version of %s.`,
 			if err := step(
 				"Export score as MIDI",
 				func() error {
-					tmpdir, err := ioutil.TempDir("", "alda-doctor")
+					tmpdir, err := os.MkdirTemp("", "alda-doctor")
 					if err != nil {
 						return err
 					}
@@ -496,7 +495,7 @@ version of %s.`,
 				indication := "received ping"
 				return util.Await(
 					func() error {
-						contents, err := ioutil.ReadFile(logFile)
+						contents, err := os.ReadFile(logFile)
 						if err != nil {
 							return err
 						}

--- a/client/cmd/export.go
+++ b/client/cmd/export.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -192,7 +191,7 @@ Currently, the only supported output format is %s.`,
 		// temporary file.
 		tmpFilename := ""
 		if outputFilename == "" {
-			tmpdir, err := ioutil.TempDir("", "alda-export")
+			tmpdir, err := os.MkdirTemp("", "alda-export")
 			if err != nil {
 				return err
 			}

--- a/client/cmd/telemetry.go
+++ b/client/cmd/telemetry.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -78,7 +78,7 @@ func readTelemetryStatus() (TelemetryStatus, error) {
 		return TelemetryNotInformed, nil
 	}
 
-	content, err := ioutil.ReadFile(telemetryStatusFile)
+	content, err := os.ReadFile(telemetryStatusFile)
 	if err != nil {
 		return -1, err
 	}
@@ -106,7 +106,7 @@ func writeTelemetryStatus(status string) error {
 		Str("filepath", telemetryStatusFilepath).
 		Msg("Writing telemetry status file.")
 
-	return ioutil.WriteFile(telemetryStatusFilepath, []byte(status), 0644)
+	return os.WriteFile(telemetryStatusFilepath, []byte(status), 0644)
 }
 
 func informUserOfTelemetry() {
@@ -258,7 +258,7 @@ func sendTelemetryRequest(command string) error {
 	}
 	defer response.Body.Close()
 
-	responseBody, err := ioutil.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/client/cmd/update.go
+++ b/client/cmd/update.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -85,7 +84,7 @@ type releaseAsset struct {
 }
 
 func downloadAssets(assets []releaseAsset) (assetsDir string, err error) {
-	outdir, err := ioutil.TempDir("", "alda-update")
+	outdir, err := os.MkdirTemp("", "alda-update")
 	if err != nil {
 		return "", err
 	}
@@ -118,7 +117,7 @@ func downloadAssets(assets []releaseAsset) (assetsDir string, err error) {
 		defer response.Body.Close()
 
 		if response.StatusCode != 200 {
-			responseBody, err := ioutil.ReadAll(response.Body)
+			responseBody, err := io.ReadAll(response.Body)
 			if err != nil {
 				log.Error().Err(err).Msg("Unable to read response body")
 			} else {
@@ -398,7 +397,7 @@ func installVersion(json *json.Container) error {
 }
 
 func errUnexpectedAldaApiResponse(response *http.Response) error {
-	responseBody, err := ioutil.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to read Alda API response body")
 	} else {

--- a/client/gen/version/main.go
+++ b/client/gen/version/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +21,7 @@ func main() {
 
 	// Read the current version from the top-level VERSION file in the Alda repo.
 	versionFile := filepath.Join(filepath.Dir(dir), "VERSION")
-	contents, err := ioutil.ReadFile(versionFile)
+	contents, err := os.ReadFile(versionFile)
 	check(err)
 	version := strings.TrimSpace(string(contents))
 

--- a/client/parser/examples_test.go
+++ b/client/parser/examples_test.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +32,7 @@ func TestExamples(t *testing.T) {
 				return nil
 			}
 
-			contents, err := ioutil.ReadFile(path)
+			contents, err := os.ReadFile(path)
 			if err != nil {
 				t.Error(label)
 				t.Error("issue reading file contents")

--- a/client/parser/parser.go
+++ b/client/parser/parser.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -321,10 +320,10 @@ func (p *parser) part() (ASTNode, error) {
 
 // An "implicit part" is an AST node that can contain:
 //
-// * Initial variable definitions at the top of the file
-// * Initial S-expressions at the top of the file, like global attributes
-// * Events (see `innerEvent`) without a part definition, in the context of
-//   continuing a previous score, e.g. in REPL input.
+//   - Initial variable definitions at the top of the file
+//   - Initial S-expressions at the top of the file, like global attributes
+//   - Events (see `innerEvent`) without a part definition, in the context of
+//     continuing a previous score, e.g. in REPL input.
 func (p *parser) implicitPart() (ASTNode, error) {
 	partEvents, err := p.partEvents()
 	if err != nil {
@@ -1126,7 +1125,7 @@ func ParseString(input string) (ASTNode, error) {
 
 // ParseFile reads a file and parses the input.
 func ParseFile(filepath string) (ASTNode, error) {
-	contents, err := ioutil.ReadFile(filepath)
+	contents, err := os.ReadFile(filepath)
 
 	if errors.Is(err, os.ErrNotExist) {
 		return ASTNode{}, help.UserFacingErrorf(

--- a/client/parser/scanner.go
+++ b/client/parser/scanner.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"unicode"
 
@@ -806,7 +806,7 @@ func Scan(filename string, input string) ([]Token, error) {
 
 // ScanFile reads a file, scans it, and returns a list of tokens.
 func ScanFile(filepath string) ([]Token, error) {
-	contents, err := ioutil.ReadFile(filepath)
+	contents, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/client/repl/client.go
+++ b/client/repl/client.go
@@ -3,7 +3,6 @@ package repl
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -114,7 +113,7 @@ func init() {
 				}
 				binaryData := []byte(res["binary-data"].(string))
 
-				return ioutil.WriteFile(filename, binaryData, 0644)
+				return os.WriteFile(filename, binaryData, 0644)
 			},
 		},
 
@@ -225,7 +224,7 @@ file into the REPL server.`,
 					return invalidArgsError(args)
 				}
 
-				contents, err := ioutil.ReadFile(client.inputFilepath)
+				contents, err := os.ReadFile(client.inputFilepath)
 				if err != nil {
 					return err
 				}
@@ -378,7 +377,7 @@ arguments will save the updated score to the same file.`,
 					return err
 				}
 
-				return ioutil.WriteFile(client.inputFilepath, []byte(scoreText), 0644)
+				return os.WriteFile(client.inputFilepath, []byte(scoreText), 0644)
 			},
 		},
 

--- a/client/repl/server.go
+++ b/client/repl/server.go
@@ -4,7 +4,6 @@ import (
 	encjson "encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net"
@@ -732,7 +731,7 @@ func (server *Server) export() ([]byte, error) {
 		return nil, err
 	}
 
-	tmpdir, err := ioutil.TempDir("", "alda-repl-server")
+	tmpdir, err := os.MkdirTemp("", "alda-repl-server")
 	if err != nil {
 		return nil, err
 	}
@@ -770,5 +769,5 @@ func (server *Server) export() ([]byte, error) {
 		return nil, err
 	}
 
-	return ioutil.ReadAll(midiFile)
+	return io.ReadAll(midiFile)
 }

--- a/client/system/dirs.go
+++ b/client/system/dirs.go
@@ -3,7 +3,6 @@ package system
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -69,7 +68,7 @@ func FindRenamedExecutables() ([]string, error) {
 
 	aldaDir := filepath.Dir(aldaPath)
 
-	fileInfos, err := ioutil.ReadDir(aldaDir)
+	fileInfos, err := os.ReadDir(aldaDir)
 	if err != nil {
 		return nil, err
 	}

--- a/client/system/stdin.go
+++ b/client/system/stdin.go
@@ -2,7 +2,7 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -34,7 +34,7 @@ func ReadStdin() ([]byte, error) {
 		return nil, ErrNoInputSupplied
 	}
 
-	bytes, err := ioutil.ReadAll(os.Stdin)
+	bytes, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
io/ioutil has been deprecated since Go 1.16
https://pkg.go.dev/io/ioutil