### PR TITLE
fix issues with excess active processes

### DIFF
--- a/client/repl/client.go
+++ b/client/repl/client.go
@@ -553,6 +553,11 @@ func (client *Client) handleCommand(name string, args string) error {
 // Disconnect closes the client's connection with the server.
 func (client *Client) Disconnect() {
 	if client.serverConn != nil {
+		_, err := client.sendRequest(map[string]interface{}{"op": "yield"})
+		if err != nil {
+			fmt.Fprint(os.Stderr, "request to yield player proccess failed")
+		}
+
 		client.serverConn.Close()
 	}
 }

--- a/client/repl/server.go
+++ b/client/repl/server.go
@@ -531,6 +531,19 @@ var ops = map[string]func(*Server, nREPLRequest){
 
 		server.respondDone(req, nil)
 	},
+
+	"yield": func(server *Server, req nREPLRequest) {
+		if err := server.withTransmitter(
+			func(transmitter transmitter.OSCTransmitter) error {
+				return transmitter.TransmitYieldMessage()
+			},
+		); err != nil {
+			server.respondError(req, err.Error(), nil)
+			return
+		}
+
+		server.respondDone(req, nil)
+	},
 }
 
 // Runs in a loop, handling requests from the queue as they come in in a

--- a/client/system/process_management.go
+++ b/client/system/process_management.go
@@ -589,7 +589,7 @@ func FillPlayerPool() error {
 // processes come up, we print a message to make it clear what we're waiting
 // for.
 func StartingPlayerProcesses() {
-	if _, err := FindAvailablePlayer(); err == ErrNoPlayersAvailable {
+	if states, _ := ReadPlayerStates(); len(states) == 0 {
 		fmt.Fprintln(os.Stderr, "Starting player processes...")
 	}
 }

--- a/client/transmitter/osc.go
+++ b/client/transmitter/osc.go
@@ -20,6 +20,10 @@ func pingMsg() *osc.Message {
 	return osc.NewMessage("/ping")
 }
 
+func yieldMsg() *osc.Message {
+	return osc.NewMessage("/yield")
+}
+
 func systemMidiExportMsg(filename string) *osc.Message {
 	msg := osc.NewMessage("/system/midi/export")
 	msg.Append(filename)
@@ -103,6 +107,11 @@ func (oe OSCTransmitter) TransmitMidiExportMessage(filename string) error {
 // TransmitPingMessage sends a "ping" message to a player process.
 func (oe OSCTransmitter) TransmitPingMessage() error {
 	return oscClient(oe.Port).Send(pingMsg())
+}
+
+// TransmitPingMessage sends a "yield" message to a player process.
+func (oe OSCTransmitter) TransmitYieldMessage() error {
+	return oscClient(oe.Port).Send(yieldMsg())
 }
 
 // TransmitPlayMessage sends a "play" message to a player process.

--- a/player/src/main/kotlin/io/alda/player/Parser.kt
+++ b/player/src/main/kotlin/io/alda/player/Parser.kt
@@ -92,6 +92,15 @@ class Updates() {
           stateManager!!.delayExpiration()
         }
 
+        //The /yield message acts as the inverse of the /ping message,
+        //where ping is used to move a player proccess into the active state
+        //yield puts the proccess in the ready state such that it may be used 
+        //by another client when neccesary
+        Regex("/yield").matches(address) -> {
+          log.debug("received yield message")
+          stateManager!!.markReady()
+        }
+
         Regex("/system/shutdown").matches(address) -> {
           val offset = args.get(0) as Int
 


### PR DESCRIPTION
Hello Dave,
I fixed the issue mentioned in issue #416. 

The issue was related to processes remaining in the active state even after they were no longer being utilized (i.e when the repl server was killed). to fix this I added the /yield command which simply sets the process to the ready state acting as the inverse of the /ping command. Just this alone didn't fix the whole problem as there was a little bug with the printing of the "Starting player processes..." message where a player process would be pinged and set to the active state purely to check if any processes exist. This issue was resolved by slightly altering the implementation of that functionality. 

Let me know if there is anything I should change.