### PR TITLE
Nested repeat fix

### DIFF
--- a/client/model/repeat.go
+++ b/client/model/repeat.go
@@ -31,13 +31,20 @@ func (repeat Repeat) JSON() *json.Container {
 // UpdateScore implements ScoreUpdate.UpdateScore by repeatedly updating the
 // score with an event a specified number of times.
 func (repeat Repeat) UpdateScore(score *Score) error {
+	previousRepetitions := make([]int32, len(score.CurrentParts))
+
 	for repetition := int32(1); repetition <= repeat.Times; repetition++ {
-		for _, part := range score.CurrentParts {
+		for i, part := range score.CurrentParts {
+			previousRepetitions[i] = part.currentRepetition
 			part.currentRepetition = repetition
 		}
 
 		if err := score.Update(repeat.Event); err != nil {
 			return err
+		}
+
+		for i, part := range score.CurrentParts {
+			part.currentRepetition = previousRepetitions[i]
 		}
 	}
 
@@ -50,12 +57,17 @@ func (repeat Repeat) DurationMs(part *Part) float64 {
 	durationMs := 0.0
 
 	for repetition := int32(1); repetition <= repeat.Times; repetition++ {
+		previousRepetition := part.currentRepetition
 		part.currentRepetition = repetition
+
 		durationMs += repeat.Event.DurationMs(part)
+
+		part.currentRepetition = previousRepetition
 	}
 
 	return durationMs
 }
+
 
 // VariableValue implements ScoreUpdate.VariableValue by returning a version of
 // the repeat where the value of the event to be repeated is captured.

--- a/client/model/repeat.go
+++ b/client/model/repeat.go
@@ -58,8 +58,8 @@ func (repeat Repeat) DurationMs(part *Part) float64 {
 
 	for repetition := int32(1); repetition <= repeat.Times; repetition++ {
 		previousRepetition := part.currentRepetition
-		part.currentRepetition = repetition
 
+		part.currentRepetition = repetition
 		durationMs += repeat.Event.DurationMs(part)
 
 		part.currentRepetition = previousRepetition
@@ -67,7 +67,6 @@ func (repeat Repeat) DurationMs(part *Part) float64 {
 
 	return durationMs
 }
-
 
 // VariableValue implements ScoreUpdate.VariableValue by returning a version of
 // the repeat where the value of the event to be repeated is captured.

--- a/client/model/repeat.go
+++ b/client/model/repeat.go
@@ -33,19 +33,22 @@ func (repeat Repeat) JSON() *json.Container {
 func (repeat Repeat) UpdateScore(score *Score) error {
 	previousRepetitions := make([]int32, len(score.CurrentParts))
 
+	for i, part := range score.CurrentParts {
+		previousRepetitions[i] = part.currentRepetition
+	}
+
 	for repetition := int32(1); repetition <= repeat.Times; repetition++ {
-		for i, part := range score.CurrentParts {
-			previousRepetitions[i] = part.currentRepetition
+		for _, part := range score.CurrentParts {
 			part.currentRepetition = repetition
 		}
 
 		if err := score.Update(repeat.Event); err != nil {
 			return err
 		}
+	}
 
-		for i, part := range score.CurrentParts {
-			part.currentRepetition = previousRepetitions[i]
-		}
+	for i, part := range score.CurrentParts {
+		part.currentRepetition = previousRepetitions[i]
 	}
 
 	return nil

--- a/client/model/repeat.go
+++ b/client/model/repeat.go
@@ -58,16 +58,14 @@ func (repeat Repeat) UpdateScore(score *Score) error {
 // of the event being repeated the specified number of times.
 func (repeat Repeat) DurationMs(part *Part) float64 {
 	durationMs := 0.0
+	previousRepetition := part.currentRepetition
 
 	for repetition := int32(1); repetition <= repeat.Times; repetition++ {
-		previousRepetition := part.currentRepetition
-
 		part.currentRepetition = repetition
 		durationMs += repeat.Event.DurationMs(part)
-
-		part.currentRepetition = previousRepetition
 	}
 
+	part.currentRepetition = previousRepetition
 	return durationMs
 }
 

--- a/client/model/repeats_test.go
+++ b/client/model/repeats_test.go
@@ -180,5 +180,59 @@ func TestRepeats(t *testing.T) {
 				expectMidiNoteNumbers(60, 60, 62, 64, 62, 64, 60),
 			},
 		},
+		scoreUpdateTestCase{
+			label: "nested repeats",
+			updates: []ScoreUpdate{
+				PartDeclaration{Names: []string{"piano"}},
+				Repeat{
+					Times: 2,
+					Event: EventSequence{
+						Events: []ScoreUpdate{
+							Repeat{
+								Times: 2,
+								Event: EventSequence{
+									Events: []ScoreUpdate{
+										Note{
+											Pitch: LetterAndAccidentals{NoteLetter: C},
+											Duration: Duration{
+												Components: []DurationComponent{
+													NoteLength{Denominator: 4},
+												},
+											},
+										},
+										OnRepetitions{
+											Repetitions: []RepetitionRange{
+												RepetitionRange{First: 1, Last: 1},
+											},
+											Event: Note{
+												Pitch: LetterAndAccidentals{NoteLetter: D},
+											},
+										},
+										OnRepetitions{
+											Repetitions: []RepetitionRange{
+												RepetitionRange{First: 2, Last: 2},
+											},
+											Event: Note{
+												Pitch: LetterAndAccidentals{NoteLetter: E},
+											},
+										},
+									},
+								},
+							},
+							OnRepetitions{
+								Repetitions: []RepetitionRange{
+									RepetitionRange{First: 2, Last: 2},
+								},
+								Event: Note{Pitch: LetterAndAccidentals{NoteLetter: D}},
+							},
+						},
+					},
+				},
+			},
+			expectations: []scoreUpdateExpectation{
+				expectNoteOffsets(0, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000),
+				expectMidiNoteNumbers(60, 62, 60, 64, 60, 62, 60, 64, 62),
+			},
+		},
 	)
 }


### PR DESCRIPTION
This should fix #401.

I have taken different approach than suggested, as it was more time efficient and less error-prone than trying to handle it from outside. Allocating a small array per repeat should not affect performance in any noticeable way.