### PR TITLE
Fixed accumulating delay. Added offset Log Debug messages.

### DIFF
--- a/client/model/score.go
+++ b/client/model/score.go
@@ -162,7 +162,7 @@ func (score *Score) PartOffsets() map[*Part]float64 {
 	offsets := map[*Part]float64{}
 
 	for _, part := range score.Parts {
-		offsets[part.origin] = part.origin.CurrentOffset
+		offsets[part.origin] = part.CurrentOffset
 	}
 
 	return offsets

--- a/client/repl/server.go
+++ b/client/repl/server.go
@@ -569,6 +569,11 @@ func (server *Server) updateScoreWithInput(
 	// option when transmitting the score.)
 	partOffsets := server.score.PartOffsets()
 
+	// Log for checking what offset value we use for the current playback.
+	for name, offset := range partOffsets {
+		log.Debug().Str("part", name.Name).Float64("offset", offset).Msg("Offset before the update, taken into account.")
+	}
+
 	// Take note of the current `eventIndex` value, so that we know where to start
 	// playing from when we want to play the new events.
 	eventIndex := server.eventIndex
@@ -585,6 +590,11 @@ func (server *Server) updateScoreWithInput(
 
 	if err := server.score.Update(scoreUpdates...); err != nil {
 		return nil, err
+	}
+
+	// Log for checking what offset value we will use next playback. (Useful for tracking by how much the offset changed.)
+	for name, offset := range server.score.PartOffsets() {
+		log.Debug().Str("part", name.Name).Float64("offset", offset).Msg("Offset after the update, not yet taken into account.")
 	}
 
 	// Add the provided `input` to our total string of input representing the


### PR DESCRIPTION
Fixes #415 

Hello.

This pull request should solve the accumulation of delay in a REPL session when using Voices. Voices still cause a slight delay compared to non-voice input, but the delay disappears once the current Voice input is ended/closed, which makes it a lot more usable. I've also added some debug logs useful for offset information in REPL sessions. I've tested this solution on the example provided in the issue and some other simple inputs.

Please, feel free to review and inform me if there are any errors with my fix. Thank you very much!