### PR TITLE
Add build instructions to main README.md (fixes #402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
   <p align="center">
   <b><a href="#installation">Installation</a></b>
   |
-  <b><a href="#building-from-source">Building</a></b>
-  |
   <b><a href="doc/index.md">Docs</a></b>
   |
   <b><a href="CHANGELOG.md">Changelog</a></b>
@@ -79,55 +77,25 @@ release of Alda.
 
 [alda-install]: https://alda.io/install
 
-## Building from Source
+Another option is to build Alda from source. Alda consists of two components:
+the **client** (written in Go) and the **player** (written in Kotlin/Java).
 
-If pre-built binaries are not available for your system (e.g., Raspberry Pi,
-BSD), you can build Alda from source. Alda consists of two components: the
-**client** (written in Go) and the **player** (written in Kotlin/Java).
+```bash
+# Clone the repo
+git clone https://github.com/alda-lang/alda.git
+cd alda
 
-### Requirements
+# Build the client and player executables
+client/bin/build
+player/bin/build
+```
 
-* **Java 8+** - Required to build and run the player.
-  * Check your version with `java -version`
-* **Go 1.19+** - Required to build the client.
-  * Download from [golang.org](https://golang.org/dl/)
+The executables are built in `client/target` and `player/target`, and the
+output of the build commands shows you the path to the built executables, which
+include builds for various OS/arch combinations.
 
-### Build Instructions
-
-1. **Clone the repository** (or download and extract a release):
-
-   ```bash
-   git clone https://github.com/alda-lang/alda.git
-   cd alda
-   ```
-
-2. **Build the player**:
-
-   ```bash
-   cd player
-   # On Linux/macOS:
-   ./bin/run
-   # On Windows:
-   bin\run
-   ```
-
-   The player binary will be located in `player/target/<version>/`.
-
-3. **Build the client**:
-
-   ```bash
-   cd ../client
-   go generate
-   go build -o alda
-   ```
-
-   The client binary (`alda` or `alda.exe`) will be in the `client/` directory.
-
-4. **Add to PATH**: Move both binaries to a directory in your PATH, or add their
-   locations to your PATH.
-
-> For detailed development instructions, see the READMEs in the
-> [client](client/README.md) and [player](player/README.md) directories.
+For more details, see the READMEs in the [client](client/README.md) and
+[player](player/README.md) directories.
 
 ## Demo
 


### PR DESCRIPTION
**Summary**
Adds a "Building from Source" section to the main [README.md] to help users who need to compile Alda themselves, such as Raspberry Pi or BSD users.

**Changes**
Added a "Building" link to the header navigation bar
Added a new "Building from Source" section with:
Clear requirements (Java 8+, Go 1.19+)
Step-by-step build instructions for both player and client
Cross-platform commands (Linux/macOS and Windows)
Links to detailed READMEs in [client] and [player] directories

**Motivation**
As noted in #402, musicians who are unfamiliar with Kotlin and Go may find it difficult to build Alda from source. This addition provides simple, accessible instructions directly in the main README, making it easier for users on unsupported platforms to get started.