### PR TITLE
Add audio mixer diagnostics to help debug silent playback on Linux

### DIFF
--- a/player/src/main/kotlin/io/alda/player/MidiEngine.kt
+++ b/player/src/main/kotlin/io/alda/player/MidiEngine.kt
@@ -330,6 +330,7 @@ class MidiEngine {
 
   init {
     info("Initializing MIDI sequencer...")
+    logAudioMixers()
     sequencer.open()
     sequencer.setSequence(sequence)
     sequencer.setTickPosition(0)
@@ -337,10 +338,13 @@ class MidiEngine {
     info("Initializing MIDI synthesizer...")
     // NB: This blocks for about a second.
     synthesizer.open()
+    log.info {
+      "Synthesizer opened: name='${synthesizer.deviceInfo.name}', vendor='${synthesizer.deviceInfo.vendor}'"
+    }
 
     // Transmit messages from the sequencer to the synthesizer.
     sequencer.getTransmitter().setReceiver(synthesizer.getReceiver())
-
+    log.info { "Sequencer transmitter connected to synthesizer receiver." }
     sequencer.addMetaEventListener(MetaEventListener { msg ->
       when (val msgType = msg.getType()) {
         CustomMetaMessage.CONTINUE.type -> {


### PR DESCRIPTION
### Problem

On some Linux distributions (e.g. Artix, NixOS), Alda produces no sound even though the MIDI sequencer and synthesizer initialize successfully and `alda doctor` reports no issues.

Because Java Sound can silently bind to a non-functional or suspended audio mixer, it is currently difficult to diagnose why playback is silent.

### Solution

This PR adds diagnostic logging during player startup to:

- List audio mixers detected by the Java Sound API
- Log the selected MIDI synthesizer device
- Confirm the sequencer → synthesizer connection

This makes silent playback issues visible and easier to debug without changing playback behavior.

### Related issue

Fixes #491