### PR TITLE
Lisp function part defined.

### DIFF
--- a/client/model/lisp.go
+++ b/client/model/lisp.go
@@ -1374,6 +1374,21 @@ func init() {
 			},
 		},
 	)
+
+	defn("part",
+		FunctionSignature{
+			ArgumentTypes: []LispForm{LispString{}},
+			Implementation: func(args ...LispForm) (LispForm, error) {
+				partName := args[0].(LispString).Value
+
+				partDecl := PartDeclaration{
+					Names: []string{partName},
+				}
+
+				return LispScoreUpdate{ScoreUpdate: partDecl}, nil
+			},
+		},
+	)
 }
 
 // LispNil is the value nil.


### PR DESCRIPTION
Added a lisp function part as per this issue: #484 

The definition is added inside init function using defn, let me know if this is not how it should be done.