### PR TITLE
Reduce default JVM memory limits for alda-player (fixes #410)

### DIFF
--- a/player/bin/build
+++ b/player/bin/build
@@ -49,7 +49,7 @@ non_windows_build="$build_dir/non-windows/alda-player"
 # Defining an initial value here means that if some logging sneaks in before we
 # can reconfigure the log path, a `tmplog` directory appears in the current
 # working directory, instead of a much uglier `${sys:logPath}` directory!
-jvm_opts="-XX:+UseG1GC -XX:MaxGCPauseMillis=100 -Xmx1024m -Xms256m -DlogPath=tmplog"
+jvm_opts="-XX:+UseG1GC -XX:MaxGCPauseMillis=100 -Xms64m -Xmx256m -DlogPath=tmplog"
 
 ### NON-WINDOWS BUILD ##############################
 


### PR DESCRIPTION
## Summary

This PR decreases the default JVM heap memory settings for `alda-player` in order to prevent the excessive RAM consumption described in #410.

## Problem

As reported, when running Alda's REPL (or multiple player processes), `alda-player` can rapidly consume several gigabytes of memory. This is especially problematic on low-memory devices like the Raspberry Pi (#403).

The current default settings allow up to **1024 MB** of maximum heap (`-Xmx1024m`), which is unnecessarily high for a music player process.

## Changes

I have updated the `jvm_opts` variable in the player build script to use more conservative memory limits:

- `-Xms64m` (initial heap size – reduced from 256 MB)
- `-Xmx256m` (maximum heap size – reduced from 1024 MB)

The other JVM options (`-XX:+UseG1GC`, `-XX:MaxGCPauseMillis=100`, `-DlogPath=tmplog`) remain unchanged.

These values were chosen because:
- **64 MB** initial heap is enough for normal operation and keeps memory usage low at startup.
- **256 MB** maximum heap provides a safe ceiling while still allowing the player to handle complex scores.
- They prevent the player from claiming huge amounts of RAM even when many processes are running.

## Notes

- This change affects the build process (`bin/build-player` or similar script) and will apply to all future releases once merged.
- Users who need more memory (e.g. for very large orchestras) can still override the JVM options at runtime, for example:  
  `java -Xmx512m -jar alda-player-fat.jar …`
- The Windows build (via launch4j) automatically picks up the same JVM options, so no separate change is needed.

Closes #410